### PR TITLE
Allow SELinux volume label on volumes

### DIFF
--- a/tests/volumes_test.py
+++ b/tests/volumes_test.py
@@ -1,0 +1,32 @@
+"""Test volume manipulation logic
+"""
+from __future__ import absolute_import, division, print_function
+
+import types
+import pytest
+from traitlets.config import LoggingConfigurable
+
+
+def test_binds(monkeypatch):
+    import jupyterhub
+    monkeypatch.setattr("jupyterhub.spawner.Spawner", _MockSpawner)
+    from dockerspawner.dockerspawner import DockerSpawner
+    d = DockerSpawner()
+    d.user = types.SimpleNamespace(name='xyz')
+    d.volumes = {
+        'a': 'b',
+        'c': {'bind': 'd', 'mode': 'Z'},
+    }
+    assert d.volume_binds == {
+        'a': {'bind': 'b', 'mode': 'rw'},
+        'c': {'bind': 'd', 'mode': 'Z'},
+    }
+    d.volumes = {'a': 'b', 'c': 'd', 'e': 'f'}
+    assert d.volume_mount_points == ['b', 'd', 'f']
+    d.volumes = {'/nfs/{username}': {'bind': '/home/{username}', 'mode': 'z'}}
+    assert d.volume_binds == {'/nfs/xyz': {'bind': '/home/xyz', 'mode': 'z'}}
+    assert d.volume_mount_points == ['/home/xyz']
+
+
+class _MockSpawner(LoggingConfigurable):
+    pass


### PR DESCRIPTION
Red Hat uses SELinux enforcing. You need to modify the SELinux context globally, or more
narrowly [add a volume label (`:Z`) to volume binds](https://docs.docker.com/engine/userguide/containers/dockervolumes/#volume-labels). docker-py does allow an arbitrary `mode` on the binds. However, you cannot specify both `ro` and `mode`.

This PR allows the following configuration for volumes:

```python
c.DockerSpawner.volumes = {
    '/nfs/{username}': {'bind': '/home/{username}', 'mode': 'Z'}
    '/other/dir': '/old/style',
}
```

In addition, this PR fixes the following issues:

1) volume_binds was formatting username on the mount_points, but volume_mount_points was not.
2) volume_mount_points should be sorted, because you might be mounting one point on another.

There's a unit test for the new code. It uses pytest, which may not be appropriate, but it's what I know. :)
