### PR TITLE
document overriding get_ip_and_port for network_mode=host

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -418,6 +418,18 @@ class DockerSpawner(Spawner):
         self.user.server.port = port
 
     def get_ip_and_port(self):
+        """Queries Docker daemon for container's IP and port.
+
+        If you are using network_mode=host, you will need to override
+        this method as follows::
+
+            async def get_ip_and_port(self):
+                return self.container_ip, self.container_port
+
+        You will need to make sure container_ip and container_port
+        are correct, which depends on the route to the container
+        and the port it opens.
+        """
         if self.use_internal_ip:
             resp = yield self.docker('inspect_container', self.container_id)
             network_settings = resp['NetworkSettings']


### PR DESCRIPTION
While this might be obvious to some, it took me quite a while to figure out how to do what I wanted to do. You could also use an [empty yield after the return](http://stackoverflow.com/a/13243870/3075806), but `async` is the better solution for Python 3.

I wanted to add the ability to set "network_name = host", but that's much more involved, and jupyterhub/jupyterhub#587 seems to be preferable.
