### PR TITLE
Change legacy IPython code to jupyter_client

### DIFF
--- a/examples/oauth/jupyterhub_config.py
+++ b/examples/oauth/jupyterhub_config.py
@@ -6,7 +6,7 @@ c = get_config()
 c.JupyterHub.spawner_class = 'dockerspawner.DockerSpawner'
 
 # The docker instances need access to the Hub, so the default loopback port doesn't work:
-from IPython.utils.localinterfaces import public_ips
+from jupyter_client.localinterfaces import public_ips
 c.JupyterHub.hub_ip = public_ips()[0]
 
 # OAuth with GitHub

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jupyterhub>=0.4
 escapism
 docker-py
+jupyter_client


### PR DESCRIPTION
juypter_client should now be used instead of ipython.utils; also adding it to the requirements