### PR TITLE
Remove jovyan home directory from systemuser image

### DIFF
--- a/systemuser/Dockerfile
+++ b/systemuser/Dockerfile
@@ -6,7 +6,8 @@ FROM jupyterhub/singleuser
 MAINTAINER Project Jupyter <jupyter@googlegroups.com>
 
 USER root
-RUN userdel jovyan
+WORKDIR /home
+RUN userdel jovyan && rm -rf /home/jovyan
 ENV SHELL /bin/bash
 ADD systemuser.sh /srv/singleuser/systemuser.sh
 # smoke test entrypoint


### PR DESCRIPTION
This commit removes the jovyan home directory from the systemuser dockerfile. This makes it such that if a user in the container does `ls /home` they only see their home directory.

The work directory must be changed in order for the docker build command to successfully remove the folder, so the work directory was changed from `/home/jovyan/work` to just `/home`