### PR TITLE
return ip, port from start

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -414,8 +414,11 @@ class DockerSpawner(Spawner):
         yield self.docker('start', self.container_id, **start_kwargs)
 
         ip, port = yield self.get_ip_and_port()
+        # store on user for pre-jupyterhub-0.7:
         self.user.server.ip = ip
         self.user.server.port = port
+        # jupyterhub 0.7 prefers returning ip, port:
+        return (ip, port)
     
     @gen.coroutine
     def get_ip_and_port(self):

--- a/dockerspawner/systemuserspawner.py
+++ b/dockerspawner/systemuserspawner.py
@@ -6,7 +6,6 @@ from traitlets import (
     Integer,
     Unicode,
 )
-from tornado import gen
 
 
 class SystemUserSpawner(DockerSpawner):
@@ -128,10 +127,9 @@ class SystemUserSpawner(DockerSpawner):
             state['user_id'] = self.user_id
         return state
 
-    @gen.coroutine
     def start(self, image=None):
         """start the single-user server in a docker container"""
-        yield super(SystemUserSpawner, self).start(
+        return super(SystemUserSpawner, self).start(
             image=image,
             extra_create_kwargs={'working_dir': self.homedir}
         )


### PR DESCRIPTION
JupyterHub 0.7 will enable returning ip, port, rather than relying on start editing db state.