### PR TITLE
Fixes Issue #90 and added code to normalize username substitution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 services:
   - docker
 before_install:
-  - pip install  -f travis-wheels/wheelhouse -v --pre -r dev-requirements.txt
+  - pip install -v --pre -r dev-requirements.txt
 install:
   - pip install -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ python:
 services:
   - docker
 before_install:
-  - pip install pyflakes
+  - pip install  -f travis-wheels/wheelhouse -v --pre -r dev-requirements.txt
 install:
-  - pip install .
+  - pip install -e .
 script:
   - pyflakes dockerspawner
   - docker build -t jupyterhub/singleuser singleuser
   - docker build -t jupyterhub/systemuser systemuser
+  - travis_retry py.test --cov dockerspawner tests -v

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 codecov
 pytest-cov
 pytest>=2.8
+pyflakes

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+codecov
+pytest-cov
+pytest>=2.8

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -217,9 +217,7 @@ class DockerSpawner(Spawner):
         Returns a sorted list of all the values in self.volumes or
         self.read_only_volumes.
         """
-        return [value.format(username=slugify(self.user.name)) for value in
-                list(self.volumes.values()) +
-                list(self.read_only_volumes.values())]
+        return sorted([value['bind'] for value in self.volume_binds.values()])
     
     @property
     def volume_binds(self):

--- a/tests/volumes_test.py
+++ b/tests/volumes_test.py
@@ -27,6 +27,17 @@ def test_binds(monkeypatch):
     assert d.volume_binds == {'/nfs/xyz': {'bind': '/home/xyz', 'mode': 'z'}}
     assert d.volume_mount_points == ['/home/xyz']
 
+def test_slugify(monkeypatch):
+    import jupyterhub
+    monkeypatch.setattr("jupyterhub.spawner.Spawner", _MockSpawner)
+    from dockerspawner.dockerspawner import DockerSpawner
+    d = DockerSpawner()
+    d.user = types.SimpleNamespace(name='s! me')
+    d.volumes = {'/opt/notebooks/{username}': '/home/jovyan/'}
+    print(d.volume_binds['/opt/notebooks/s-me'])
+    assert d.volume_binds['/opt/notebooks/s-me'] == {'bind': '/home/jovyan/', 'mode': 'rw'}
+
+
 
 class _MockSpawner(LoggingConfigurable):
     pass


### PR DESCRIPTION
Added and tested code as suggested in Issue #90 discussion. Found additional issue with usernames that cannot be used as filenames when inserting them into volume labels. I added slugify code from Django framework to normalize usernames so they can be filenames.