### PR TITLE
revert slugify

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -23,18 +23,6 @@ from traitlets import (
 )
 
 
-def slugify(value):
-    """
-    Normalizes string, converts to lowercase, removes non-alpha characters,
-    and converts spaces to hyphens.
-    """
-    import unicodedata,re
-    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
-    value = re.sub('[^\w\s-]', '', value).strip().lower()
-    value = re.sub('[-\s]+', '-', value)
-    return value
-
-
 class UnicodeOrFalse(Unicode):
     info_text = 'a unicode string or False'
     def validate(self, obj, value):
@@ -42,7 +30,7 @@ class UnicodeOrFalse(Unicode):
             return value
         return super(UnicodeOrFalse, self).validate(obj, value)
 
-    
+
 class DockerSpawner(Spawner):
 
     _executor = None
@@ -504,7 +492,7 @@ class DockerSpawner(Spawner):
             {'/host/dir': {'bind': '/guest/dir': 'mode': 'rw'}}
         """
         def _fmt(v):
-            return v.format(username=slugify(self.user.name))
+            return v.format(username=self.user.name)
 
         for k, v in volumes.items():
             m = mode

--- a/tests/volumes_test.py
+++ b/tests/volumes_test.py
@@ -27,17 +27,6 @@ def test_binds(monkeypatch):
     assert d.volume_binds == {'/nfs/xyz': {'bind': '/home/xyz', 'mode': 'z'}}
     assert d.volume_mount_points == ['/home/xyz']
 
-def test_slugify(monkeypatch):
-    import jupyterhub
-    monkeypatch.setattr("jupyterhub.spawner.Spawner", _MockSpawner)
-    from dockerspawner.dockerspawner import DockerSpawner
-    d = DockerSpawner()
-    d.user = types.SimpleNamespace(name='s! me')
-    d.volumes = {'/opt/notebooks/{username}': '/home/jovyan/'}
-    print(d.volume_binds['/opt/notebooks/s-me'])
-    assert d.volume_binds['/opt/notebooks/s-me'] == {'bind': '/home/jovyan/', 'mode': 'rw'}
-
-
 
 class _MockSpawner(LoggingConfigurable):
     pass


### PR DESCRIPTION
it was scrubbing valid identifiers.

- non-ascii characters should be allowed in paths
- spaces should not occur in usernames, but they are valid in files, anyway
- unicode normalizing probably shouldn't occur, either

@whitead do you have any examples of the usernames that prompted slugify?