### PR TITLE
Improve README to better explain both spawners

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+We mainly follow the [IPython Contributing Guide](https://github.com/ipython/ipython/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ the host file/directory to the container (referred to as guest)
 file/directory mount point, set the `c.DockerSpawner.volumes` to specify
 the guest mount point (bind) for the volume.
 
-If you use {username} in either the host or guest file/directory path,
-username substitution will be done and {username} will be replaced with
+If you use `{username}` in either the host or guest file/directory path,
+username substitution will be done and `{username}` will be replaced with
 the current user's name.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -1,19 +1,54 @@
+**[Prerequisites](#prerequisites)** |
+**[Installation](#installation)** |
+**[Configuration](#configuration)** |
+**[Docker](#docker)** |
+**[Contributing](#contributing)** |
+**[License](#license)** |
+**[Getting help](#getting-help)**
+
+
 # DockerSpawner
 
-Enables [JupyterHub](https://github.com/jupyterhub/jupyterhub) to spawn
-user servers in docker containers.
+** DockerSpawner enables [JupyterHub](https://github.com/jupyterhub/jupyterhub) 
+to spawn single user notebook servers in Docker containers.
 
-## Setting up the spawner
+
+## Prerequisites
+
+Python version 3.3 and above is required.
+
+Clone the repo:
+
+```bash
+
+    git clone https://github.com/jupyterhub/dockerspawner.git
+    cd dockerspawner
+```
 
 Install dependencies:
 
+```bash
     pip install -r requirements.txt
+```
 
-Install to the system:
 
+## Installation
+
+Install dockerspawner to the system:
+
+```bash
     python setup.py install
+```
 
-### DockerSpawner
+
+## Configuration
+
+### Choose a spawner
+
+- DockerSpawner
+- SystemUserSpawner
+
+#### DockerSpawner
 
 Tell JupyterHub to use DockerSpawner by adding the following line to 
 your `jupyterhub_config.py`:
@@ -23,7 +58,7 @@ your `jupyterhub_config.py`:
 There is a complete example in [examples/oauth](examples/oauth) for
 using GitHub OAuth to authenticate users, and spawn containers with docker.
 
-### SystemUserSpawner
+#### SystemUserSpawner
 
 If you want to spawn notebook servers for users that correspond to system users,
 you can use the SystemUserSpawner instead. Add the following to your
@@ -44,6 +79,7 @@ For a full example of how `SystemUserSpawner` is used, see the
 repository (this additionally runs the JupyterHub server within a docker
 container, and authenticates users using GitHub OAuth).
 
+
 ### Using Docker Swarm
 
 Both `DockerSpawner` and `SystemUserSpawner` are compatible with
@@ -56,6 +92,7 @@ c.DockerSpawner.container_ip = "0.0.0.0"
 
 which will tell DockerSpawner/SystemUserSpawner to get the container IP address
 and port number from `docker port`.
+
 
 ## Building the docker images
 
@@ -77,3 +114,49 @@ Or the `jupyterhub/systemuser` container with:
 or use `docker pull jupyterhub/systemuser` to download it from [Docker
 Hub](https://registry.hub.docker.com/u/jupyterhub/systemuser/).
 
+
+## Contributing
+
+If you would like to contribute to the project, please read our 
+[contributor documentation](http://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html)
+and the [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+For a **development install**, clone the [repository](https://github.com/jupyterhub/dockerspawner) 
+and then install from source:
+
+```bash
+git clone https://github.com/jupyterhub/dockerspaawner
+cd dockerspawner
+pip3 install -r dev-requirements.txt -e .
+```
+
+
+## License
+
+We use a shared copyright model that enables all contributors to maintain the
+copyright on their contributions.
+
+All code is licensed under the terms of the revised BSD license.
+
+
+## Getting help
+
+We encourage you to ask questions on the [mailing list](https://groups.google.com/forum/#!forum/jupyter),
+and you may participate in development discussions or get live help on 
+[Gitter](https://gitter.im/jupyterhub/jupyterhub).
+
+
+## Resources
+
+### Dockerspawner and JupyterHub
+
+- [Reporting Issues](https://github.com/jupyterhub/dockerspawner/issues)
+- JupyterHub tutorial | [Repo](https://github.com/jupyterhub/jupyterhub-tutorial)
+  | [Tutorial documentation](http://jupyterhub-tutorial.readthedocs.io/en/latest/)
+- [Documentation for JupyterHub](http://jupyterhub.readthedocs.io/en/latest/) | [PDF (latest)](https://media.readthedocs.org/pdf/jupyterhub/latest/jupyterhub.pdf) | [PDF (stable)](https://media.readthedocs.org/pdf/jupyterhub/stable/jupyterhub.pdf)
+- [Documentation for JupyterHub's REST API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyterhub/master/docs/rest-api.yml#/default)
+
+### Project Jupyter
+
+- [Documentation for Project Jupyter](http://jupyter.readthedocs.io/en/latest/index.html) | [PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)
+- [Project Jupyter website](https://jupyter.org)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # DockerSpawner
 
-** DockerSpawner** enables [JupyterHub](https://github.com/jupyterhub/jupyterhub) 
+**DockerSpawner** enables [JupyterHub](https://github.com/jupyterhub/jupyterhub) 
 to spawn single user notebook servers in Docker containers.
 
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,20 @@ Two basic types of spawners are available for dockerspawner:
   spawn single user notebook servers that correspond to the system's 
   users.
 
-In general, DockerSpawner will likely be used more frequently since it
-is more general and flexible than SystemUserSpawner. SystemUserSpawner
-is handy when you wish to use the system users and user home directories
-that already exist on a system.
+In most cases, we recommend using DockerSpawner. Use cases where you
+may wish to use SystemUserSpawner are:
+
+- You are using docker just for environment management, but are running
+  on a system where the users already have accounts and files they
+  should be able to access from within the container. For example, you
+  wish to use the system users and user home directories that
+  already exist on a system.
+- You are using an external service that relies on distinct unix user
+  ownership and permissions (i.e. nbgrader).
+  
+If neither of those cases applies, DockerSpawner is probably the right
+choice.
+
 
 ### DockerSpawner
 
@@ -143,10 +153,16 @@ containter from [Docker Hub](https://registry.hub.docker.com/u/jupyterhub/system
 
 ## Data persistence
 
+The simplest version of persistence to the host filesystem is to
+isolate users in the filesystem, but leave everything owned by the same
+'actual' user with DockerSpawner. That is, using docker mounts to
+isolate user files, not ownership or permissions on the host.
+
 If you wish to persist hub or user notebook data, additional configuration
-is required. See JupyterHub configuration documentation for more
-information on data persistence and Docker documentation on mounting
-data volumes.
+is required. See Docker documentation on [data volumes] for more
+information on data persistence. For example, a primitive example using
+user home directories is described in Min Ragan-Kelley's
+[PyData London workshop].
 
 
 ## Contributing
@@ -194,3 +210,8 @@ and you may participate in development discussions or get live help on
 
 - [Documentation for Project Jupyter](http://jupyter.readthedocs.io/en/latest/index.html) | [PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)
 - [Project Jupyter website](https://jupyter.org)
+
+
+  [data volumes]: https://docs.docker.com/engine/tutorials/dockervolumes/#/data-volumes
+  [PyData London workshop]: https://youtu.be/gSVvxOchT8Y?t=1h13m30s
+  

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ command.
 
 ### Data persistence and DockerSpawner
 
-With `DockerSpawner`, the home directory, `/home/jupyter`, is *not* 
-persistent by default, so some configuration is required to do so unless
+With `DockerSpawner`, the user's home directory
+is *not* persistent by default, so some configuration is required to do so unless
 the directory is to be used with temporary or demonstration JupyterHub
 deployments.
 
@@ -144,6 +144,10 @@ the guest mount point (bind) for the volume.
 If you use `{username}` in either the host or guest file/directory path,
 username substitution will be done and `{username}` will be replaced with
 the current user's name.
+
+(Note: The jupyter/docker-stacks notebook images run the Notebook server as user
+`jovyan` and set the user's notebook directory to `/home/jovyan/work`.)
+
 
 ```python
 # Explicitly set notebook directory because we'll be mounting a host volume to

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **[Prerequisites](#prerequisites)** |
 **[Installation](#installation)** |
 **[Configuration](#configuration)** |
-**[Docker](#docker)** |
+**[Building the Docker images](#building-the-docker-images)** |
 **[Contributing](#contributing)** |
 **[License](#license)** |
 **[Getting help](#getting-help)**
@@ -9,7 +9,7 @@
 
 # DockerSpawner
 
-** DockerSpawner enables [JupyterHub](https://github.com/jupyterhub/jupyterhub) 
+** DockerSpawner** enables [JupyterHub](https://github.com/jupyterhub/jupyterhub) 
 to spawn single user notebook servers in Docker containers.
 
 
@@ -45,26 +45,43 @@ Install dockerspawner to the system:
 
 ### Choose a spawner
 
-- DockerSpawner
-- SystemUserSpawner
+Two basic types of spawners are available for dockerspawner:
 
-#### DockerSpawner
+- [DockerSpawner](#DockerSpawner): useful if you would like to spawn 
+  single user notebook servers on the fly. It will take an
+  authenticated user and spawn a notebook server in a Docker container
+  for the user.
+
+- [SystemUserSpawner](#SystemUserSpawner): useful if you would like to
+  spawn single user notebook servers that correspond to the system's 
+  users.
+
+In general, DockerSpawner will likely be used more frequently since it
+is more general and flexible than SystemUserSpawner. SystemUserSpawner
+is handy when you wish to use the system users and user home directories
+that already exist on a system.
+
+### DockerSpawner
 
 Tell JupyterHub to use DockerSpawner by adding the following line to 
 your `jupyterhub_config.py`:
 
+```python
     c.JupyterHub.spawner_class = 'dockerspawner.DockerSpawner'
+```
 
 There is a complete example in [examples/oauth](examples/oauth) for
 using GitHub OAuth to authenticate users, and spawn containers with docker.
 
-#### SystemUserSpawner
+### SystemUserSpawner
 
 If you want to spawn notebook servers for users that correspond to system users,
 you can use the SystemUserSpawner instead. Add the following to your
 `jupyterhub_config.py`:
 
+```python
     c.JupyterHub.spawner_class = 'dockerspawner.SystemUserSpawner'
+```
 
 The SystemUserSpawner will also need to know where the user home directories
 are on the host. By default, it expects them to be in `/home/<username>`, but if
@@ -72,47 +89,64 @@ you want to change this, you'll need to further modify the
 `jupyterhub_config.py`. For example, the following will look for a user's home
 directory on the host system at `/volumes/user/<username>`:
 
+```python
     c.SystemUserSpawner.host_homedir_format_string = '/volumes/user/{username}'
+```
 
 For a full example of how `SystemUserSpawner` is used, see the
 [compmodels-jupyterhub](https://github.com/jhamrick/compmodels-jupyterhub)
 repository (this additionally runs the JupyterHub server within a docker
 container, and authenticates users using GitHub OAuth).
 
-
 ### Using Docker Swarm
 
 Both `DockerSpawner` and `SystemUserSpawner` are compatible with
-[Docker Swarm](https://docs.docker.com/swarm/). Simply add to your
-`jupyterhub_config.py` file:
+[Docker Swarm](https://docs.docker.com/swarm/) when multiple system
+nodes will be used in a cluster for JupyterHub. Simply add `0.0.0.0`
+to your `jupyterhub_config.py` file as the `container_ip`:
 
-```
+```python
 c.DockerSpawner.container_ip = "0.0.0.0"
 ```
 
-which will tell DockerSpawner/SystemUserSpawner to get the container IP address
-and port number from `docker port`.
+This will configure DockerSpawner and SystemUserSpawner to get
+the container IP address and port number using the `docker port`
+command.
 
 
-## Building the docker images
+## Building the Docker images
 
 ### Single user notebook server
 
 Build the `jupyterhub/singleuser` container with:
 
+```bash
     docker build -t jupyterhub/singleuser singleuser
+```
 
-or use `docker pull jupyterhub/singleuser` to download it from [Docker
-Hub](https://registry.hub.docker.com/u/jupyterhub/singleuser/).
+You may also use `docker pull jupyterhub/singleuser` to download the
+container from [Docker Hub](https://registry.hub.docker.com/u/jupyterhub/singleuser/).
 
 ### System user notebook server
 
-Or the `jupyterhub/systemuser` container with:
+This is used with [`SystemUserSpawner`](#systemuserspawner).
 
+Build the `jupyterhub/systemuser` container with:
+
+```bash
     docker build -t jupyterhub/systemuser systemuser
+```
 
-or use `docker pull jupyterhub/systemuser` to download it from [Docker
-Hub](https://registry.hub.docker.com/u/jupyterhub/systemuser/).
+You may also use `docker pull jupyterhub/systemuser` to download the
+containter from [Docker Hub](https://registry.hub.docker.com/u/jupyterhub/systemuser/).
+
+
+## Data persistence
+
+If you wish to persist hub or user notebook data, additional configuration
+is required. See JupyterHub configuration documentation for more
+information on data persistence and Docker documentation on mounting
+data volumes.
 
 
 ## Contributing

--- a/singleuser/README.md
+++ b/singleuser/README.md
@@ -8,12 +8,12 @@ to be used with the
 [DockerSpawner](https://github.com/jupyterhub/dockerspawner/blob/master/dockerspawner/dockerspawner.py)
 class to launch user notebook servers within docker containers.
 
-This particular server runs (within the container) as the `jupyter` user, with
-home directory at `/home/jupyter`, and the IPython example notebooks at
-`/home/jupyter/examples`.
+This particular server runs (within the container) as the `jovyan` user, with
+home directory at `/home/jovyan`, and the IPython example notebooks at
+`/home/jovyan/examples`.
 
 ## Note on persistence
 
-This home directory, `/home/jupyter`, is *not* persistent by default,
+This home directory, `/home/jovyan`, is *not* persistent by default,
 so some configuration is required unless the directory is to be used
 with temporary or demonstration JupyterHub deployments.


### PR DESCRIPTION
The README is a bit light on details of DockerSpawner vs. SystemSpawner. Which to use? Why?