### PR TITLE
Modified arguments to start in SystemUserSpawner

### DIFF
--- a/dockerspawner/systemuserspawner.py
+++ b/dockerspawner/systemuserspawner.py
@@ -127,9 +127,18 @@ class SystemUserSpawner(DockerSpawner):
             state['user_id'] = self.user_id
         return state
 
-    def start(self, image=None):
+    def start(self, image=None, extra_create_kwargs=None,
+        extra_start_kwargs=None, extra_host_config=None):
         """start the single-user server in a docker container"""
+        if extra_create_kwargs is None:
+            extra_create_kwargs = {}
+
+        if 'working_dir' not in extra_create_kwargs:
+            extra_create_kwargs['working_dir'] = self.homedir
+
         return super(SystemUserSpawner, self).start(
             image=image,
-            extra_create_kwargs={'working_dir': self.homedir}
+            extra_create_kwargs=extra_create_kwargs,
+            extra_start_kwargs=extra_start_kwargs,
+            extra_host_config=extra_host_config
         )


### PR DESCRIPTION
The start method in SystemUserSpawner did not accept the same arguments as
the start mehtod in DockerSpawner. This made subclassing SystemUserSpawner
difficult as passing arguments was not possible.

This commit changes the arguments of start to match those of the
DockerSpawner method. It also modified the call to the super, passing in the
added arguments.

This commit does change the functionality a bit, as `working_dir` is no
longer forced to be `start.homedir` and can be overwritten.