### PR TITLE
use internal ip connections when setting network name

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -176,14 +176,15 @@ class DockerSpawner(Spawner):
         help=dedent(
             """
             Enable the usage of the internal docker ip. This is useful if you are running
-            jupyterhub (as a container) and the user containers within the same docker engine.
+            jupyterhub (as a container) and the user containers within the same docker network.
             E.g. by mounting the docker socket of the host into the jupyterhub container.
+            Default is True if using a docker network, False if bridge or host networking is used.
             """
         )
     )
     @default('use_internal_ip')
     def _default_use_ip(self):
-        # setting network_name to something other than bridge, host implies use_internal_ip
+        # setting network_name to something other than bridge or host implies use_internal_ip
         if self.network_name not in {'bridge', 'host'}:
             return True
         else:
@@ -208,9 +209,10 @@ class DockerSpawner(Spawner):
         config=True,
         help=dedent(
             """
-            The name of the docker network from which to retrieve the internal IP address. Defaults to the default
-            docker network 'bridge'. You need to set this if you run your jupyterhub containers in a
-            non-standard network. Only has an effect if use_internal_ip=True.
+            Run the containers on this docker network.
+            If it is an internal docker network, the Hub should be on the same network,
+            as internal docker IP addresses will be used.
+            For bridge networking, external ports will be bound.
             """
         )
     )


### PR DESCRIPTION
This came up when I was doing [these swarm experiments](https://github.com/minrk/jupyterhub-swarm/blob/master/hub-inside/jupyterhub_config.py#L20), where I discovered that to tell DockerSpawner to listen internally on a docker network required three separate config options:

1. network_name (the name of the network when retrieving the ip)
2. use_internal_ip (whether to lookup internal connection info at all)
3. `host_config.network_mode` (tell the container to run on the given network)

I've updated it so that setting `network_name` signals that docker networking is in use and internal connections should be used. So what was:

```python
c.DockerSpawner.network_name = 'jupyterhub'
c.DockerSpawner.use_internal_ip = True
c.DockerSpawner.extra_host_config = {
    'network_mode': 'jupyterhub',
}
```

is now:

```python
c.DockerSpawner.network_name = 'jupyterhub'
```