### PR TITLE
force conversion of port to int

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -493,7 +493,10 @@ class DockerSpawner(Spawner):
             if resp is None:
                 raise RuntimeError("Failed to get port info for %s" % self.container_id)
             ip = resp[0]['HostIp']
-            port = int(resp[0]['HostPort'])
+            port = resp[0]['HostPort']
+            if not isinstance(port, int):
+                self.log.warning("casting port to int from value "+repr(port))
+                port = int(port)
         return ip, port
 
     def get_network_ip(self, network_settings):

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -493,7 +493,7 @@ class DockerSpawner(Spawner):
             if resp is None:
                 raise RuntimeError("Failed to get port info for %s" % self.container_id)
             ip = resp[0]['HostIp']
-            port = resp[0]['HostPort']
+            port = int(resp[0]['HostPort'])
         return ip, port
 
     def get_network_ip(self, network_settings):


### PR DESCRIPTION
This fixes a problem where docker-py is returning a string for the port for the following configuration:
```
$ docker --version
Docker version 17.05.0-ce, build 89658be
$ python3
Python 3.4.2 (default, Oct  8 2014, 10:45:20) 
[GCC 4.9.1] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import docker
>>> docker.__version__
'2.2.1'
```

however the call to the docker module actually generates the following, which make be the underlying issue:

```
[I 2017-06-02 20:07:41.727 JupyterHub dockerspawner:498] Bad message (TypeError('not all arguments converted during string formatting',)): {'args'
: ([{'HostIp': '127.0.0.1', 'HostPort': '10245'}],), 'levelname': 'INFO', 'funcName': 'get_ip_and_port', 'thread': 140445252167424, 'module': 'doc
kerspawner', 'process': 2320, 'exc_info': None, 'lineno': 498, 'threadName': 'MainThread', 'levelno': 20, 'stack_info': None, 'msg': 'resp', 'exc_
text': None, 'relativeCreated': 27513.266563415527, 'msecs': 727.851152420044, 'processName': 'MainProcess', 'created': 1496434061.7278512, 'filen
ame': 'dockerspawner.py', 'pathname': '/srv/jupyterhub/src/dockerspawner/dockerspawner/dockerspawner.py', 'name': 'JupyterHub'}
[I 2017-06-02 20:07:41.727 JupyterHub dockerspawner:503] Bad message (TypeError('not all arguments converted during string formatting',)): {'args'
: ('127.0.0.1', 10245), 'levelname': 'INFO', 'funcName': 'get_ip_and_port', 'thread': 140445252167424, 'module': 'dockerspawner', 'process': 2320,
 'exc_info': None, 'lineno': 503, 'threadName': 'MainThread', 'levelno': 20, 'stack_info': None, 'msg': 'ip, port', 'exc_text': None, 'relativeCre
ated': 27513.40413093567, 'msecs': 727.9887199401855, 'processName': 'MainProcess', 'created': 1496434061.7279887, 'filename': 'dockerspawner.py',
 'pathname': '/srv/jupyterhub/src/dockerspawner/dockerspawner/dockerspawner.py', 'name': 'JupyterHub'}
[I 2017-06-02 20:07:41.728 JupyterHub dockerspawner:466] Bad message (TypeError('not all arguments converted during string formatting',)): {'args'
: (('127.0.0.1', 10245),), 'levelname': 'INFO', 'funcName': 'start', 'thread': 140445252167424, 'module': 'dockerspawner', 'process': 2320, 'exc_i
nfo': None, 'lineno': 466, 'threadName': 'MainThread', 'levelno': 20, 'stack_info': None, 'msg': '(ip, port)', 'exc_text': None, 'relativeCreated'
: 27514.24217224121, 'msecs': 728.8267612457275, 'processName': 'MainProcess', 'created': 1496434061.7288268, 'filename': 'dockerspawner.py', 'pat
hname': '/srv/jupyterhub/src/dockerspawner/dockerspawner/dockerspawner.py', 'name': 'JupyterHub'}
```