### PR TITLE
Allow override of docker client api version

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -50,12 +50,12 @@ class DockerSpawner(Spawner):
         """single global client instance"""
         cls = self.__class__
         if cls._client is None:
-            kwargs = {}
+            kwargs = {version='auto'}
             if self.tls_config:
                 kwargs['tls'] = docker.tls.TLSConfig(**self.tls_config)
             kwargs.update(kwargs_from_env())
             kwargs.update(self.client_kwargs)
-            client = docker.APIClient(version='auto', **kwargs)
+            client = docker.APIClient(**kwargs)
             cls._client = client
         return cls._client
 

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -50,7 +50,7 @@ class DockerSpawner(Spawner):
         """single global client instance"""
         cls = self.__class__
         if cls._client is None:
-            kwargs = {version='auto'}
+            kwargs = {'version':'auto'}
             if self.tls_config:
                 kwargs['tls'] = docker.tls.TLSConfig(**self.tls_config)
             kwargs.update(kwargs_from_env())


### PR DESCRIPTION
In some cases, it is needed to override the docker API client version. For example, we can get error messages with an outdated Swarm cluster, like this :

    docker.errors.APIError: 400 Client Error: Bad Request ("b'your client is too new (API version 1.27). The newest supported API version is 1.26.0'")

This modification keeps the default behavior, but allows to override the version via client_kwargs if necessary