### PR TITLE
tag images with JupyterHub version on DockerHub

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -33,6 +33,9 @@ class UnicodeOrFalse(Unicode):
             return value
         return super(UnicodeOrFalse, self).validate(obj, value)
 
+import jupyterhub
+_jupyterhub_xy = '%i.%i' % (jupyterhub.version_info[:2])
+
 class DockerSpawner(Spawner):
 
     _executor = None
@@ -62,7 +65,7 @@ class DockerSpawner(Spawner):
     container_id = Unicode()
     container_ip = Unicode('127.0.0.1', config=True)
     container_port = Int(8888, min=1, max=65535, config=True)
-    container_image = Unicode("jupyterhub/singleuser", config=True)
+    container_image = Unicode("jupyterhub/singleuser:%s" % _jupyterhub_xy, config=True)
     container_prefix = Unicode(
         "jupyter",
         config=True,

--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -1,13 +1,9 @@
 # Build as jupyterhub/singleuser
 # Run with the DockerSpawner in JupyterHub
 
-FROM jupyter/scipy-notebook
-
+FROM jupyter/base-notebook:b4dd11e16ae4
 MAINTAINER Project Jupyter <jupyter@googlegroups.com>
 
-# no need for singleuser Dockerfile anymore,
-# all scripts have been ported to jupyter/base-notebook docker image
-
-# smoke test that it's importable at least
-RUN /usr/local/bin/start-singleuser.sh -h
-CMD ["/usr/local/bin/start-singleuser.sh"]
+ADD install_jupyterhub /tmp/install_jupyterhub
+ARG JUPYTERHUB_VERSION=master
+RUN python /tmp/install_jupyterhub

--- a/singleuser/hooks/build
+++ b/singleuser/hooks/build
@@ -1,23 +1,26 @@
 #!/bin/bash
-set -x
+set -ex
 bash --version
 
 env | sort
-stable=0.7.2
-for V in master 0.7 0.7.2; do
+stable=0.7
+for V in master 0.7; do
     docker build --build-arg JUPYTERHUB_VERSION=$V -t $DOCKER_REPO:$V .
 done
 echo "tagging $IMAGE_NAME"
 docker tag $DOCKER_REPO:$stable $IMAGE_NAME
 
-echo "getting master"
-# tag X.Y for master
-master_v=$(docker run --rm -it $DOCKER_REPO:master jupyterhub --version)
-split=( ${master_v//./ } )
-master_xy="${split[0]}.${split[1]}"
-env
+function get_hub_version() {
+  rm -f hub_version
+  docker run --rm -v $PWD:/version -i $DOCKER_REPO:$1 sh -c 'jupyterhub --version > /version/hub_version'
+  hub_xyz=$(cat hub_version)
+  split=( ${hub_xyz//./ } )
+  hub_xy="${split[0]}.${split[1]}"
+}
+# tag e.g. 0.7.2 with 0.7
+get_hub_version 0.7
+docker tag $DOCKER_REPO:0.7 $DOCKER_REPO:$hub_xyz
 
-echo $master_v
-echo $master_xy
-
-docker tag $DOCKER_REPO:master $DOCKER_REPO:$master_xy
+# tag e.g. 0.8 with master
+get_hub_version master
+docker tag $DOCKER_REPO:master $DOCKER_REPO:$hub_xy

--- a/singleuser/hooks/build
+++ b/singleuser/hooks/build
@@ -1,26 +1,11 @@
 #!/bin/bash
 set -ex
-bash --version
 
-env | sort
 stable=0.7
+
 for V in master 0.7; do
     docker build --build-arg JUPYTERHUB_VERSION=$V -t $DOCKER_REPO:$V .
 done
+
 echo "tagging $IMAGE_NAME"
 docker tag $DOCKER_REPO:$stable $IMAGE_NAME
-
-function get_hub_version() {
-  rm -f hub_version
-  docker run --rm -v $PWD:/version -i $DOCKER_REPO:$1 sh -c 'jupyterhub --version > /version/hub_version'
-  hub_xyz=$(cat hub_version)
-  split=( ${hub_xyz//./ } )
-  hub_xy="${split[0]}.${split[1]}"
-}
-# tag e.g. 0.7.2 with 0.7
-get_hub_version 0.7
-docker tag $DOCKER_REPO:0.7 $DOCKER_REPO:$hub_xyz
-
-# tag e.g. 0.8 with master
-get_hub_version master
-docker tag $DOCKER_REPO:master $DOCKER_REPO:$hub_xy

--- a/singleuser/hooks/build
+++ b/singleuser/hooks/build
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+bash --version
+
+env | sort
+stable=0.7.2
+for V in master 0.7 0.7.2; do
+    docker build --build-arg JUPYTERHUB_VERSION=$V -t $DOCKER_REPO:$V .
+done
+echo "tagging $IMAGE_NAME"
+docker tag $DOCKER_REPO:$stable $IMAGE_NAME
+
+echo "getting master"
+# tag X.Y for master
+master_v=$(docker run --rm -it $DOCKER_REPO:master jupyterhub --version)
+split=( ${master_v//./ } )
+master_xy="${split[0]}.${split[1]}"
+env
+
+echo $master_v
+echo $master_xy
+
+docker tag $DOCKER_REPO:master $DOCKER_REPO:$master_xy

--- a/singleuser/hooks/post_push
+++ b/singleuser/hooks/post_push
@@ -1,0 +1,6 @@
+#!/bin/bash
+env
+for V in master 0.8 0.7 0.7.2; do
+  docker push $DOCKER_REPO:$V
+done
+

--- a/singleuser/hooks/post_push
+++ b/singleuser/hooks/post_push
@@ -1,6 +1,23 @@
 #!/bin/bash
-env
-for V in master 0.8 0.7 0.7.2; do
+
+for V in master 0.7; do
   docker push $DOCKER_REPO:$V
 done
 
+function get_hub_version() {
+  rm -f hub_version
+  V=$1
+  docker run --rm -v $PWD:/version -u $(id -u) -i $DOCKER_REPO:$V sh -c 'jupyterhub --version > /version/hub_version'
+  hub_xyz=$(cat hub_version)
+  split=( ${hub_xyz//./ } )
+  hub_xy="${split[0]}.${split[1]}"
+}
+# tag e.g. 0.7.2 with 0.7
+get_hub_version 0.7
+docker tag $DOCKER_REPO:0.7 $DOCKER_REPO:$hub_xyz
+docker push $DOCKER_REPO:$hub_xyz
+
+# tag e.g. 0.8 with master
+get_hub_version master
+docker tag $DOCKER_REPO:master $DOCKER_REPO:$hub_xy
+docker push $DOCKER_REPO:$hub_xy

--- a/singleuser/install_jupyterhub
+++ b/singleuser/install_jupyterhub
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import os
+from subprocess import check_call
+
+V = os.environ['JUPYTERHUB_VERSION']
+
+if V == 'master':
+  check_call([
+    'pip', 'install', 'https://github.com/jupyterhub/jupyterhub/archive/master.tar.gz',
+  ])
+else:
+  version_info = [ int(part) for part in V.split('.') ]
+  version_info[-1] += 1
+  upper_bound = '.'.join(map(str, version_info))
+  vs = '>=%s,<%s' % (V, upper_bound)
+  check_call([
+      'pip', 'install', '--upgrade',
+      '--upgrade-strategy', 'only-if-needed',
+      'jupyterhub%s' % vs
+  ])
+  

--- a/singleuser/install_jupyterhub
+++ b/singleuser/install_jupyterhub
@@ -4,18 +4,17 @@ from subprocess import check_call
 
 V = os.environ['JUPYTERHUB_VERSION']
 
+pip_install = [
+    'pip', 'install', '--no-cache', '--upgrade',
+    '--upgrade-strategy', 'only-if-needed',
+]
 if V == 'master':
-  check_call([
-    'pip', 'install', 'https://github.com/jupyterhub/jupyterhub/archive/master.tar.gz',
-  ])
+    req = 'https://github.com/jupyterhub/jupyterhub/archive/master.tar.gz'
 else:
-  version_info = [ int(part) for part in V.split('.') ]
-  version_info[-1] += 1
-  upper_bound = '.'.join(map(str, version_info))
-  vs = '>=%s,<%s' % (V, upper_bound)
-  check_call([
-      'pip', 'install', '--upgrade',
-      '--upgrade-strategy', 'only-if-needed',
-      'jupyterhub%s' % vs
-  ])
-  
+    version_info = [ int(part) for part in V.split('.') ]
+    version_info[-1] += 1
+    upper_bound = '.'.join(map(str, version_info))
+    vs = '>=%s,<%s' % (V, upper_bound)
+    req = 'jupyterhub%s' % vs
+
+check_call(pip_install + [req])


### PR DESCRIPTION
generates jupyterhub/singleuser:0.7 and jupyterhub/singleuser:0.8

and picks these by default, so that the default behavior of DockerSpawner is to launch with an image that works.

Following tags are created: 0.7 (aliases: 0.7.2, latest), master (aliases: 0.8)