### PR TITLE
remove container on start if self.remove_containers

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -477,6 +477,14 @@ class DockerSpawner(Spawner):
 
         """
         container = yield self.get_container()
+        if container and self.remove_containers:
+            self.log.warning(
+                "Removing container that should have been cleaned up: %s (id: %s)",
+                self.container_name, self.container_id[:7])
+            # remove the container, as well as any associated volumes
+            yield self.docker('remove_container', self.container_id, v=True)
+            container = None
+
         if container is None:
             image = image or self.image
             if self._user_set_cmd:


### PR DESCRIPTION
ensures that a failed start or previous `.remove_containers = False` run doesn't bleed into the next start

closes #182