### PR TITLE
ensure internal port is exposed

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -502,6 +502,10 @@ class DockerSpawner(Spawner):
                 name=self.container_name,
                 command=cmd,
             )
+
+            # ensure internal port is exposed
+            create_kwargs['ports'] = {'%i/tcp' % self.port: None}
+
             create_kwargs.update(self.extra_create_kwargs)
             if extra_create_kwargs:
                 create_kwargs.update(extra_create_kwargs)


### PR DESCRIPTION
removes assumption that image has `EXPOSE port` line