### PR TITLE
Fix deprecation warning

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -265,7 +265,7 @@ class DockerSpawner(Spawner):
             warnings.warn(
                 "DockerSpawner.hub_ip_connect is no longer needed with JupyterHub 0.8."
                 "  Use JupyterHub.hub_connect_ip instead.",
-                warnings.DeprecationWarning,
+                DeprecationWarning,
             )
 
     use_internal_ip = Bool(False,


### PR DESCRIPTION
After patching my jupyterhub to work I next ran into this error:
```python-traceback
    Traceback (most recent call last):
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\tornado\web.py", line 1511, in _execute
        result = yield result
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\tornado\gen.py", line 1055, in run
        value = future.result()
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\tornado\concurrent.py", line 238, in result
        raise_exc_info(self._exc_info)
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\tornado\gen.py", line 1069, in run
        yielded = self.gen.send(value)
      File "c:\dev\src\jupyterhub\jupyterhub\handlers\login.py", line 87, in post
        if user.spawner:
      File "c:\dev\src\jupyterhub\jupyterhub\user.py", line 224, in __getattr__
        return object.__getattribute__(self, attr)  # <---- PATCHED HERE!!
      File "c:\dev\src\jupyterhub\jupyterhub\user.py", line 214, in spawner
        return self.spawners['']
      File "c:\dev\src\jupyterhub\jupyterhub\user.py", line 105, in __getitem__
        self[key] = self.spawner_factory(key)
      File "c:\dev\src\jupyterhub\jupyterhub\user.py", line 207, in _new_spawner
        spawner = spawner_class(**spawn_kwargs)
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\traitlets\config\configurable.py", line 84, in __init__
        self.config = config
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\traitlets\traitlets.py", line 585, in __set__
        self.set(obj, value)
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\traitlets\traitlets.py", line 574, in set
        obj._notify_trait(self.name, old_value, new_value)
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\traitlets\traitlets.py", line 1139, in _notify_trait
        type='change',
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\traitlets\traitlets.py", line 1176, in notify_change
        c(change)
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\traitlets\traitlets.py", line 819, in compatible_observer
        return func(self, change)
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\traitlets\config\configurable.py", line 186, in _config_changed
        self._load_config(change.new, traits=traits, section_names=section_names)
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\traitlets\config\configurable.py", line 168, in _load_config
        warn(msg)
      File "C:\Miniconda3\envs\jupyterhub\lib\contextlib.py", line 89, in __exit__
        next(self.gen)
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\traitlets\traitlets.py", line 1131, in hold_trait_notifications
        self.notify_change(change)
      File "C:\Miniconda3\envs\jupyterhub\lib\site-packages\traitlets\traitlets.py", line 1176, in notify_change
        c(change)
      File "c:\dev\src\dockerspawner\dockerspawner\dockerspawner.py", line 268, in _ip_connect_changed
        warnings.DeprecationWarning,
    AttributeError: module 'warnings' has no attribute 'DeprecationWarning'
```