### PR TITLE
Add container_name_template config

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -147,19 +147,19 @@ class DockerSpawner(Spawner):
         config=True,
         help=dedent(
             """
-            Prefix for container names. See user_container_name for full container name for a particular
+            Prefix for container names. See container_name_template for full container name for a particular
             user.
             """
         )
     )
 
-    user_container_name = Unicode(
+    container_name_template = Unicode(
         "{prefix}-{username}",
         config=True,
         help=dedent(
             """
-            Name of the container: with {username}, {imagename}, {container_prefix} replacements.
-            The default user_container_name is <prefix>-<username> for backward compatibility
+            Name of the container: with {username}, {imagename}, {prefix} replacements.
+            The default container_name_template is <prefix>-<username> for backward compatibility
             """
         )
     )
@@ -377,7 +377,7 @@ class DockerSpawner(Spawner):
         escaped_container_image = self.image.replace("/", "_")
         server_name = getattr(self, 'name', '')
         d = {'username' : self.escaped_name, 'imagename' : escaped_container_image, 'servername' : server_name, 'prefix' : self.container_prefix}
-        return self.user_container_name.format(**d)
+        return self.container_name_template.format(**d)
 
     def load_state(self, state):
         super(DockerSpawner, self).load_state(state)

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -142,12 +142,24 @@ class DockerSpawner(Spawner):
         """
     )
 
-    user_container_name = Unicode(
-        "{username}-{imagename}",
+    container_prefix = Unicode(
+        "jupyter",
         config=True,
         help=dedent(
             """
-            The name of the container name: with {username} and {imagename} replacement
+            Prefix for container names. See user_container_name for full container name for a particular
+            user.
+            """
+        )
+    )
+
+    user_container_name = Unicode(
+        "{prefix}-{username}",
+        config=True,
+        help=dedent(
+            """
+            Name of the container: with {username}, {imagename}, {container_prefix} replacements.
+            The default user_container_name is <prefix>-<username> for backward compatibility
             """
         )
     )
@@ -363,7 +375,8 @@ class DockerSpawner(Spawner):
     @property
     def container_name(self):
         escaped_container_image = self.image.replace("/", "_")
-        d = {'username' : self.escaped_name, 'imagename' : escaped_container_image}
+        server_name = getattr(self, 'name', '')
+        d = {'username' : self.escaped_name, 'imagename' : escaped_container_image, 'servername' : server_name, 'prefix' : self.container_prefix}
         return self.user_container_name.format(**d)
 
     def load_state(self, state):

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -142,13 +142,12 @@ class DockerSpawner(Spawner):
         """
     )
 
-    container_prefix = Unicode(
-        "jupyter",
+    user_container_name = Unicode(
+        "{username}-{imagename}",
         config=True,
         help=dedent(
             """
-            Prefix for container names. The full container name for a particular
-            user will be <prefix>-<username>.
+            The name of the container name: with {username} and {imagename} replacement
             """
         )
     )
@@ -363,7 +362,9 @@ class DockerSpawner(Spawner):
 
     @property
     def container_name(self):
-        return "{}-{}".format(self.container_prefix, self.escaped_name)
+        escaped_container_image = self.image.replace("/", "_")
+        d = {'username' : self.escaped_name, 'imagename' : escaped_container_image}
+        return self.user_container_name.format(**d)
 
     def load_state(self, state):
         super(DockerSpawner, self).load_state(state)


### PR DESCRIPTION
Hi,

this is a little modification to allow a per user, per docker-image container name (needed when using profilespawner):

Because i want user to have multiple docker container instances with differents docker images, i added the "user_container_name" option (by default "{username}-{imagename}"), and remove "container_prefix" which is no longer needed (because "user_container_name" can be "prefix-{username}-{imagename}-suffix")

For instance, i use profilespawner and user can select "jupyterhub/systemuser", or "jupyter/r-notebook" docker image:

With this patch the user "bob" have 2 docker containers:

bob-jupyterhub_systemuser and bob-jupyter_r-notebook. No need to remove a container to use other image.