### PR TITLE
SwarmSpawner inherits from DockerSpawner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
 services:
   - docker
 before_install:
+  - nvm install 10; nvm use 10
+  - npm install -g configurable-http-proxy
   - pip install -v --pre -r dev-requirements.txt
   - pip install --pre jupyterhub==${JUPYTERHUB}.*
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 sudo: required
 language: python
 python:
-    - 3.5
+  - 3.5
+env:
+  - JUPYTERHUB=0.8
+  - JUPYTERHUB=0.9
 services:
   - docker
 before_install:
   - pip install -v --pre -r dev-requirements.txt
+  - pip install --pre jupyterhub==${JUPYTERHUB}.*
 install:
   - pip install -e .
 script:
-  - pyflakes dockerspawner
+  - pyflakes dockerspawner tests
+  - docker swarm init
+  - docker pull jupyterhub/singleuser:$JUPYTERHUB
+  - docker swarm init
   - travis_retry py.test --cov dockerspawner tests -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ env:
 services:
   - docker
 before_install:
+  - docker swarm init
   - nvm install 10; nvm use 10
   - npm install -g configurable-http-proxy
-  - pip install -v --pre -r dev-requirements.txt jupyterhub==${JUPYTERHUB}.* ${EXTRA_PIP}
+  - pip install --pre -r dev-requirements.txt jupyterhub==${JUPYTERHUB}.* ${EXTRA_PIP}
 install:
   - pip install -e .
+  - pip freeze
 script:
-  - pyflakes dockerspawner tests
-  - docker swarm init
+  - pyflakes dockerspawner
   - docker pull jupyterhub/singleuser:$JUPYTERHUB
-  - docker swarm init
   - travis_retry py.test --cov dockerspawner tests -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,14 @@ language: python
 python:
   - 3.5
 env:
-  - JUPYTERHUB=0.8
+  - JUPYTERHUB=0.8 EXTRA_PIP='tornado<5'
   - JUPYTERHUB=0.9
 services:
   - docker
 before_install:
   - nvm install 10; nvm use 10
   - npm install -g configurable-http-proxy
-  - pip install -v --pre -r dev-requirements.txt
-  - pip install --pre jupyterhub==${JUPYTERHUB}.*
+  - pip install -v --pre -r dev-requirements.txt jupyterhub==${JUPYTERHUB}.* ${EXTRA_PIP}
 install:
   - pip install -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@ language: python
 python:
   - 3.5
 env:
-  - JUPYTERHUB=0.8 EXTRA_PIP='tornado<5'
-  - JUPYTERHUB=0.9
+  global:
+    - ASYNC_TEST_TIMEOUT=30
+  matrix:
+    - JUPYTERHUB=0.8 EXTRA_PIP='tornado<5'
+    - JUPYTERHUB=0.9
 services:
   - docker
 before_install:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,6 @@
 codecov
-pytest-cov
 pytest>=2.8
+pytest-cov
+pytest-tornado
 pyflakes
+notebook

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -16,34 +16,31 @@ from tornado import gen
 
 from escapism import escape
 from jupyterhub.spawner import Spawner
-from traitlets import (
-    Dict,
-    Unicode,
-    Bool,
-    Int,
-    Any,
-    default,
-    observe,
-)
+from traitlets import Dict, Unicode, Bool, Int, Any, default, observe
 
 from .volumenamingstrategy import default_format_volume_name
 
 
 class UnicodeOrFalse(Unicode):
-    info_text = 'a unicode string or False'
+    info_text = "a unicode string or False"
+
     def validate(self, obj, value):
         if value is False:
             return value
+
         return super(UnicodeOrFalse, self).validate(obj, value)
 
+
 import jupyterhub
-_jupyterhub_xy = '%i.%i' % (jupyterhub.version_info[:2])
+
+_jupyterhub_xy = "%i.%i" % (jupyterhub.version_info[:2])
 
 
 class DockerSpawner(Spawner):
     """A Spawner for JupyterHub that runs each user's server in a separate docker container"""
 
     _executor = None
+
     @property
     def executor(self):
         """single global executor"""
@@ -53,14 +50,15 @@ class DockerSpawner(Spawner):
         return cls._executor
 
     _client = None
+
     @property
     def client(self):
         """single global client instance"""
         cls = self.__class__
         if cls._client is None:
-            kwargs = {'version':'auto'}
+            kwargs = {"version": "auto"}
             if self.tls_config:
-                kwargs['tls'] = docker.tls.TLSConfig(**self.tls_config)
+                kwargs["tls"] = docker.tls.TLSConfig(**self.tls_config)
             kwargs.update(kwargs_from_env())
             kwargs.update(self.client_kwargs)
             client = docker.APIClient(**kwargs)
@@ -71,13 +69,16 @@ class DockerSpawner(Spawner):
     # default command is that of the container,
     # but user can override it via config
     _user_set_cmd = False
-    @observe('cmd')
+
+    @observe("cmd")
     def _cmd_changed(self, change):
         self._user_set_cmd = True
 
     object_id = Unicode()
-    # thee type of object we create
-    object_type = 'container'
+    # the type of object we create
+    object_type = "container"
+    # the field containing the object id
+    object_id_key = "Id"
 
     @property
     def container_id(self):
@@ -93,8 +94,9 @@ class DockerSpawner(Spawner):
     # it is not the ip in the container,
     # but the host ip of the port forwarded to the container
     # when use_internal_ip is False
-    container_ip = Unicode('127.0.0.1', config=True)
-    @observe('container_ip')
+    container_ip = Unicode("127.0.0.1", config=True)
+
+    @observe("container_ip")
     def _container_ip_deprecated(self, change):
         self.log.warning(
             "DockerSpawner.container_ip is deprecated in dockerspawner-0.9."
@@ -102,7 +104,8 @@ class DockerSpawner(Spawner):
         )
         self.host_ip = change.new
 
-    host_ip = Unicode('127.0.0.1',
+    host_ip = Unicode(
+        "127.0.0.1",
         help="""The ip address on the host on which to expose the container's port
 
         Typically 127.0.0.1, but can be public interfaces as well
@@ -117,7 +120,8 @@ class DockerSpawner(Spawner):
     # unlike container_ip, container_port is the internal port
     # on which the server is bound.
     container_port = Int(8888, min=1, max=65535, config=True)
-    @observe('container_port')
+
+    @observe("container_port")
     def _container_port_changed(self, change):
         self.log.warning(
             "DockerSpawner.container_port is deprecated in dockerspawner 0.9."
@@ -126,17 +130,20 @@ class DockerSpawner(Spawner):
         self.port = change.new
 
     # fix default port to 8888, used in the container
-    @default('port')
+
+    @default("port")
     def _port_default(self):
         return 8888
 
     # default to listening on all-interfaces in the container
-    @default('ip')
+
+    @default("ip")
     def _ip_default(self):
-        return '0.0.0.0'
+        return "0.0.0.0"
 
     container_image = Unicode("jupyterhub/singleuser:%s" % _jupyterhub_xy, config=True)
-    @observe('container_image')
+
+    @observe("container_image")
     def _container_image_changed(self, change):
         self.log.warning(
             "DockerSpawner.container_image is deprecated in dockerspawner 0.9."
@@ -144,7 +151,9 @@ class DockerSpawner(Spawner):
         )
         self.image = change.new
 
-    image = Unicode("jupyterhub/singleuser:%s" % _jupyterhub_xy, config=True,
+    image = Unicode(
+        "jupyterhub/singleuser:%s" % _jupyterhub_xy,
+        config=True,
         help="""The image to use for single-user servers.
 
         This image should have the same version of jupyterhub as
@@ -156,22 +165,18 @@ class DockerSpawner(Spawner):
 
         Any of the jupyter docker-stacks should work without additional config,
         as long as the version of jupyterhub in the image is compatible.
-        """
+        """,
     )
 
-    container_prefix = Unicode(
-        config=True,
-        help="DEPRECATED in 0.10. Use prefix",
-    )
+    container_prefix = Unicode(config=True, help="DEPRECATED in 0.10. Use prefix")
 
     container_name_template = Unicode(
-        config=True,
-        help="DEPRECATED in 0.10. Use name_template",
+        config=True, help="DEPRECATED in 0.10. Use name_template"
     )
 
-    @observe('container_name_template', 'container_prefix')
+    @observe("container_name_template", "container_prefix")
     def _deprecate_container_alias(self, change):
-        new_name = change.name[len('container_'):]
+        new_name = change.name[len("container_"):]
         setattr(self, new_name, change.new)
 
     prefix = Unicode(
@@ -182,7 +187,7 @@ class DockerSpawner(Spawner):
             Prefix for container names. See name_template for full container name for a particular
             user's server.
             """
-        )
+        ),
     )
 
     name_template = Unicode(
@@ -193,7 +198,7 @@ class DockerSpawner(Spawner):
             Name of the container or service: with {username}, {imagename}, {prefix} replacements.
             The default name_template is <prefix>-<username> for backward compatibility.
             """
-        )
+        ),
     )
 
     client_kwargs = Dict(
@@ -221,7 +226,7 @@ class DockerSpawner(Spawner):
             file/directory path, it will be replaced with the current
             user's name.
             """
-        )
+        ),
     )
 
     read_only_volumes = Dict(
@@ -237,7 +242,7 @@ class DockerSpawner(Spawner):
             file/directory path, it will be replaced with the current
             user's name.
             """
-        )
+        ),
     )
 
     format_volume_name = Any(
@@ -245,43 +250,57 @@ class DockerSpawner(Spawner):
 
         Reusable implementations should go in dockerspawner.VolumeNamingStrategy, tests should go in ...
         """
-    ).tag(config=True)
+    ).tag(
+        config=True
+    )
 
     def default_format_volume_name(template, spawner):
         return template.format(username=spawner.user.name)
 
-    @default('format_volume_name')
+    @default("format_volume_name")
     def _get_default_format_volume_name(self):
         return default_format_volume_name
 
-    use_docker_client_env = Bool(True, config=True,
-        help="DEPRECATED. Docker env variables are always used if present.")
-    @observe('use_docker_client_env')
+    use_docker_client_env = Bool(
+        True,
+        config=True,
+        help="DEPRECATED. Docker env variables are always used if present.",
+    )
+
+    @observe("use_docker_client_env")
     def _client_env_changed(self):
-        self.log.warning("DockerSpawner.use_docker_client_env is deprecated and ignored."
-        "  Docker environment variables are always used if defined.")
-    tls_config = Dict(config=True,
+        self.log.warning(
+            "DockerSpawner.use_docker_client_env is deprecated and ignored."
+            "  Docker environment variables are always used if defined."
+        )
+
+    tls_config = Dict(
+        config=True,
         help="""Arguments to pass to docker TLS configuration.
 
         See docker.client.TLSConfig constructor for options.
-        """
+        """,
     )
-    tls = tls_verify = tls_ca = tls_cert = \
-    tls_key = tls_assert_hostname = Any(config=True,
-        help="""DEPRECATED. Use DockerSpawner.tls_config dict to set any TLS options."""
+    tls = tls_verify = tls_ca = tls_cert = tls_key = tls_assert_hostname = Any(
+        config=True,
+        help="""DEPRECATED. Use DockerSpawner.tls_config dict to set any TLS options.""",
     )
-    @observe('tls', 'tls_verify', 'tls_ca', 'tls_cert', 'tls_key', 'tls_assert_hostname')
+
+    @observe(
+        "tls", "tls_verify", "tls_ca", "tls_cert", "tls_key", "tls_assert_hostname"
+    )
     def _tls_changed(self, change):
-        self.log.warning("%s config ignored, use %s.tls_config dict to set full TLS configuration.",
-            change.name, self.__class__.__name__,
+        self.log.warning(
+            "%s config ignored, use %s.tls_config dict to set full TLS configuration.",
+            change.name,
+            self.__class__.__name__,
         )
 
     remove_containers = Bool(
-        False,
-        config=True,
-        help="DEPRECATED in DockerSpawner 0.10. Use .remove",
+        False, config=True, help="DEPRECATED in DockerSpawner 0.10. Use .remove"
     )
-    @observe('remove_containers')
+
+    @observe("remove_containers")
     def _deprecate_remove_containers(self, change):
         # preserve remove_containers alias to .remove
         self.remove = change.new
@@ -293,7 +312,7 @@ class DockerSpawner(Spawner):
         If True, delete containers when servers are stopped.
 
         This will destroy any data in the container not stored in mounted volumes.
-        """
+        """,
     )
 
     @property
@@ -302,11 +321,15 @@ class DockerSpawner(Spawner):
         # so JupyterHub >= 0.7.1 won't cleanup our API token
         return not self.remove
 
-    extra_create_kwargs = Dict(config=True, help="Additional args to pass for container create")
-    extra_host_config = Dict(config=True, help="Additional args to create_host_config for container create")
+    extra_create_kwargs = Dict(
+        config=True, help="Additional args to pass for container create"
+    )
+    extra_host_config = Dict(
+        config=True, help="Additional args to create_host_config for container create"
+    )
 
-    _docker_safe_chars = set(string.ascii_letters + string.digits + '-')
-    _docker_escape_char = '_'
+    _docker_safe_chars = set(string.ascii_letters + string.digits + "-")
+    _docker_escape_char = "_"
 
     hub_ip_connect = Unicode(
         config=True,
@@ -317,9 +340,10 @@ class DockerSpawner(Spawner):
             when the hub_api is bound to listen on all ports or is
             running inside of a container.
             """
-        )
+        ),
     )
-    @observe('hub_ip_connect')
+
+    @observe("hub_ip_connect")
     def _ip_connect_changed(self, change):
         if jupyterhub.version_info >= (0, 8):
             warnings.warn(
@@ -328,7 +352,8 @@ class DockerSpawner(Spawner):
                 DeprecationWarning,
             )
 
-    use_internal_ip = Bool(False,
+    use_internal_ip = Bool(
+        False,
         config=True,
         help=dedent(
             """
@@ -337,13 +362,15 @@ class DockerSpawner(Spawner):
             E.g. by mounting the docker socket of the host into the jupyterhub container.
             Default is True if using a docker network, False if bridge or host networking is used.
             """
-        )
+        ),
     )
-    @default('use_internal_ip')
+
+    @default("use_internal_ip")
     def _default_use_ip(self):
         # setting network_name to something other than bridge or host implies use_internal_ip
-        if self.network_name not in {'bridge', 'host'}:
+        if self.network_name not in {"bridge", "host"}:
             return True
+
         else:
             return False
 
@@ -358,7 +385,7 @@ class DockerSpawner(Spawner):
             If the Hub is running in a Docker container,
             this can simplify routing because all traffic will be using docker hostnames.
             """
-        )
+        ),
     )
 
     network_name = Unicode(
@@ -371,7 +398,7 @@ class DockerSpawner(Spawner):
             as internal docker IP addresses will be used.
             For bridge networking, external ports will be bound.
             """
-        )
+        ),
     )
 
     @property
@@ -382,6 +409,7 @@ class DockerSpawner(Spawner):
         """
         if self.tls_cert and self.tls_key:
             return (self.tls_cert, self.tls_key)
+
         return None
 
     @property
@@ -393,7 +421,7 @@ class DockerSpawner(Spawner):
         Returns a sorted list of all the values in self.volumes or
         self.read_only_volumes.
         """
-        return sorted([value['bind'] for value in self.volume_binds.values()])
+        return sorted([value["bind"] for value in self.volume_binds.values()])
 
     @property
     def volume_binds(self):
@@ -409,63 +437,55 @@ class DockerSpawner(Spawner):
 
         """
         binds = self._volumes_to_binds(self.volumes, {})
-        return self._volumes_to_binds(self.read_only_volumes, binds, mode='ro')
+        return self._volumes_to_binds(self.read_only_volumes, binds, mode="ro")
 
     _escaped_name = None
+
     @property
     def escaped_name(self):
         """Escape the username so it's safe for docker objects"""
         if self._escaped_name is None:
-            self._escaped_name = escape(self.user.name,
+            self._escaped_name = escape(
+                self.user.name,
                 safe=self._docker_safe_chars,
                 escape_char=self._docker_escape_char,
             )
         return self._escaped_name
 
     object_id = Unicode(allow_none=True)
+
     @property
     def object_name(self):
         """Render the name of our container/service using name_template"""
         escaped_image = self.image.replace("/", "_")
-        server_name = getattr(self, 'name', '')
+        server_name = getattr(self, "name", "")
         d = {
-            'username': self.escaped_name,
-            'imagename' : escaped_image,
-            'servername' : server_name,
-            'prefix' : self.prefix,
+            "username": self.escaped_name,
+            "imagename": escaped_image,
+            "servername": server_name,
+            "prefix": self.prefix,
         }
         return self.name_template.format(**d)
 
-    # container_ prefixes for our object
-    @property
-    def container_id(self):
-        return self.object_id
-
-    @property
-    def container_name(self):
-        return self.object_name
-
     def load_state(self, state):
         super(DockerSpawner, self).load_state(state)
-        if 'container_id' in state:
+        if "container_id" in state:
             # backward-compatibility for dockerspawner < 0.10
-            self.object_id = state.get('container_id')
+            self.object_id = state.get("container_id")
         else:
-            self.object_id = state.get('object_id', '')
+            self.object_id = state.get("object_id", "")
 
     def get_state(self):
         state = super(DockerSpawner, self).get_state()
         if self.object_id:
-            state['object_id'] = self.object_id
+            state["object_id"] = self.object_id
         return state
 
     def _public_hub_api_url(self):
-        proto, path = self.hub.api_url.split('://', 1)
-        ip, rest = path.split(':', 1)
-        return '{proto}://{ip}:{rest}'.format(
-            proto = proto,
-            ip = self.hub_ip_connect,
-            rest = rest
+        proto, path = self.hub.api_url.split("://", 1)
+        ip, rest = path.split(":", 1)
+        return "{proto}://{ip}:{rest}".format(
+            proto=proto, ip=self.hub_ip_connect, rest=rest
         )
 
     def _env_keep_default(self):
@@ -478,10 +498,11 @@ class DockerSpawner(Spawner):
             # JupyterHub 0.7 specifies --hub-api-url
             # on the command-line, which is hard to update
             for idx, arg in enumerate(list(args)):
-                if arg.startswith('--hub-api-url='):
+                if arg.startswith("--hub-api-url="):
                     args.pop(idx)
                     break
-            args.append('--hub-api-url=%s' % self._public_hub_api_url())
+
+            args.append("--hub-api-url=%s" % self._public_hub_api_url())
         return args
 
     def _docker(self, method, *args, **kwargs):
@@ -507,15 +528,14 @@ class DockerSpawner(Spawner):
             self.log.warning("Container not found: %s", self.container_name)
             return 0
 
-        container_state = container['State']
+        container_state = container["State"]
         self.log.debug(
-            "Container %s status: %s",
-            self.container_id[:7],
-            pformat(container_state),
+            "Container %s status: %s", self.container_id[:7], pformat(container_state)
         )
 
         if container_state["Running"]:
             return None
+
         else:
             return (
                 "ExitCode={ExitCode}, "
@@ -527,20 +547,16 @@ class DockerSpawner(Spawner):
     def get_object(self):
         self.log.debug("Getting container '%s'", self.object_name)
         try:
-            obj = yield self.docker(
-                'inspect_%s' % self.object_type, self.object_name
-            )
-            self.object_id = obj['Id']
+            obj = yield self.docker("inspect_%s" % self.object_type, self.object_name)
+            self.object_id = obj[self.object_id_key]
         except APIError as e:
             if e.response.status_code == 404:
                 self.log.info(
-                    "%s '%s' is gone",
-                    self.object_type.title(),
-                    self.object_name,
+                    "%s '%s' is gone", self.object_type.title(), self.object_name
                 )
                 obj = None
                 # my container is gone, forget my id
-                self.object_id = ''
+                self.object_id = ""
             elif e.response.status_code == 500:
                 self.log.info(
                     "%s '%s' is on unhealthy node",
@@ -549,12 +565,82 @@ class DockerSpawner(Spawner):
                 )
                 obj = None
                 # my container is unhealthy, forget my id
-                self.object_id = ''
+                self.object_id = ""
             else:
                 raise
+
         return obj
 
     @gen.coroutine
+    def get_command(self):
+        """Get the command to run (full command + args)"""
+        if self._user_set_cmd:
+            cmd = self.cmd
+        else:
+            image_info = yield self.docker("inspect_image", self.image)
+            cmd = image_info["Config"]["Cmd"]
+        return cmd + self.get_args()
+
+    @gen.coroutine
+    def remove_object(self):
+        self.log.info("Removing %s %s", self.object_type, self.object_id)
+        # remove the container, as well as any associated volumes
+        yield self.docker("remove_" + self.object_type, self.object_id, v=True)
+
+    @gen.coroutine
+    def create_object(self):
+        """Create the container/service object"""
+        create_kwargs = dict(
+            image=self.image,
+            environment=self.get_env(),
+            volumes=self.volume_mount_points,
+            name=self.container_name,
+            command=(yield self.get_command()),
+        )
+
+        # ensure internal port is exposed
+        create_kwargs["ports"] = {"%i/tcp" % self.port: None}
+
+        create_kwargs.update(self.extra_create_kwargs)
+
+        # build the dictionary of keyword arguments for host_config
+        host_config = dict(binds=self.volume_binds, links=self.links)
+
+        if getattr(self, "mem_limit", None) is not None:
+            # If jupyterhub version > 0.7, mem_limit is a traitlet that can
+            # be directly configured. If so, use it to set mem_limit.
+            # this will still be overriden by extra_host_config
+            host_config["mem_limit"] = self.mem_limit
+
+        if not self.use_internal_ip:
+            host_config["port_bindings"] = {self.port: (self.host_ip,)}
+        host_config.update(self.extra_host_config)
+        host_config.setdefault("network_mode", self.network_name)
+
+        self.log.debug("Starting host with config: %s", host_config)
+
+        host_config = self.client.create_host_config(**host_config)
+        create_kwargs.setdefault("host_config", {}).update(host_config)
+
+        # create the container
+        obj = yield self.docker("create_container", **create_kwargs)
+        return obj
+
+    @gen.coroutine
+    def start_object(self):
+        """Actually start the container/service
+
+        e.g. calling `docker start`
+        """
+        return self.docker("start", self.container_id)
+
+    @gen.coroutine
+    def stop_object(self):
+        """Actually start the container/service
+
+        e.g. calling `docker start`
+        """
+        return self.docker("stop", self.container_id)
 
     @gen.coroutine
     def start(self, image=None, extra_create_kwargs=None, extra_host_config=None):
@@ -563,97 +649,74 @@ class DockerSpawner(Spawner):
         Additional arguments to create/host config/etc. can be specified
         via .extra_create_kwargs and .extra_host_config attributes.
         """
-        container = yield self.get_object()
-        if container and self.remove:
+
         if image:
             self.log.warning("Specifying image via .start args is deprecated")
             self.image = image
         if extra_create_kwargs:
-            self.log.warning("Specifying extra_create_kwargs via .start args is deprecated")
+            self.log.warning(
+                "Specifying extra_create_kwargs via .start args is deprecated"
+            )
             self.extra_create_kwargs.update(extra_create_kwargs)
         if extra_host_config:
-            self.log.warning("Specifying extra_host_config via .start args is deprecated")
+            self.log.warning(
+                "Specifying extra_host_config via .start args is deprecated"
+            )
             self.extra_host_config.update(extra_host_config)
 
         image = self.image
 
+        obj = yield self.get_object()
+        if obj and self.remove:
             self.log.warning(
-                "Removing container that should have been cleaned up: %s (id: %s)",
-                self.container_name, self.container_id[:7])
-            # remove the container, as well as any associated volumes
-            yield self.docker('remove_container', container["Id"], v=True)
-            container = None
-
-        if container is None:
-            if self._user_set_cmd:
-                cmd = self.cmd
-            else:
-                image_info = yield self.docker('inspect_image', image)
-                cmd = image_info['Config']['Cmd']
-            cmd = cmd + self.get_args()
-
-            # build the dictionary of keyword arguments for create_container
-            create_kwargs = dict(
-                image=image,
-                environment=self.get_env(),
-                volumes=self.volume_mount_points,
-                name=self.container_name,
-                command=cmd,
+                "Removing %s that should have been cleaned up: %s (id: %s)",
+                self.object_type,
+                self.object_name,
+                self.object_id[:7],
             )
+            yield self.remove_object()
 
-            # ensure internal port is exposed
-            create_kwargs['ports'] = {'%i/tcp' % self.port: None}
+            obj = None
 
-            create_kwargs.update(self.extra_create_kwargs)
-
-            # build the dictionary of keyword arguments for host_config
-            host_config = dict(binds=self.volume_binds, links=self.links)
-
-            if getattr(self, 'mem_limit', None) is not None:
-                # If jupyterhub version > 0.7, mem_limit is a traitlet that can
-                # be directly configured. If so, use it to set mem_limit.
-                # this will still be overriden by extra_host_config
-                host_config['mem_limit'] = self.mem_limit
-
-            if not self.use_internal_ip:
-                host_config['port_bindings'] = {self.port: (self.host_ip,)}
-            host_config.update(self.extra_host_config)
-            host_config.setdefault('network_mode', self.network_name)
-
-            self.log.debug("Starting host with config: %s", host_config)
-
-            host_config = self.client.create_host_config(**host_config)
-            create_kwargs.setdefault('host_config', {}).update(host_config)
-
-            # create the container
-            resp = yield self.docker('create_container', **create_kwargs)
-            self.object_id = resp['Id']
+        if obj is None:
+            obj = yield self.create_object()
+            self.object_id = obj[self.object_id_key]
             self.log.info(
-                "Created container '%s' (id: %s) from image %s",
-                self.container_name, self.object_id[:7], image)
+                "Created %s %s (id: %s) from image %s",
+                self.object_type,
+                self.object_name,
+                self.object_id[:7],
+                self.image,
+            )
 
         else:
             self.log.info(
-                "Found existing container '%s' (id: %s)",
-                self.container_name, self.object_id[:7])
+                "Found existing %s %s (id: %s)",
+                self.object_type,
+                self.object_name,
+                self.object_id[:7],
+            )
             # Handle re-using API token.
             # Get the API token from the environment variables
             # of the running container:
-            for line in container['Config']['Env']:
-                if line.startswith(('JPY_API_TOKEN=', 'JUPYTERHUB_API_TOKEN=')):
-                    self.api_token = line.split('=', 1)[1]
+            for line in obj["Config"]["Env"]:
+                if line.startswith(("JPY_API_TOKEN=", "JUPYTERHUB_API_TOKEN=")):
+                    self.api_token = line.split("=", 1)[1]
                     break
 
         # TODO: handle unpause
         self.log.info(
-            "Starting container '%s' (id: %s)",
-            self.container_name, self.container_id[:7])
+            "Starting %s %s (id: %s)",
+            self.object_type,
+            self.object_name,
+            self.container_id[:7],
+        )
 
         # start the container
-        yield self.docker('start', self.container_id)
+        yield self.start_object()
 
         ip, port = yield self.get_ip_and_port()
-        if jupyterhub.version_info < (0,7):
+        if jupyterhub.version_info < (0, 7):
             # store on user for pre-jupyterhub-0.7:
             self.user.server.ip = ip
             self.user.server.port = port
@@ -676,29 +739,30 @@ class DockerSpawner(Spawner):
         and the port it opens.
         """
         if self.use_internal_ip:
-            resp = yield self.docker('inspect_container', self.container_id)
-            network_settings = resp['NetworkSettings']
-            if 'Networks' in network_settings:
+            resp = yield self.docker("inspect_container", self.container_id)
+            network_settings = resp["NetworkSettings"]
+            if "Networks" in network_settings:
                 ip = self.get_network_ip(network_settings)
             else:  # Fallback for old versions of docker (<1.9) without network management
-                ip = network_settings['IPAddress']
+                ip = network_settings["IPAddress"]
             port = self.port
         else:
-            resp = yield self.docker('port', self.container_id, self.port)
+            resp = yield self.docker("port", self.container_id, self.port)
             if resp is None:
                 raise RuntimeError("Failed to get port info for %s" % self.container_id)
-            ip = resp[0]['HostIp']
-            port = int(resp[0]['HostPort'])
 
-        if ip == '0.0.0.0':
+            ip = resp[0]["HostIp"]
+            port = int(resp[0]["HostPort"])
+
+        if ip == "0.0.0.0":
             ip = urlparse(self.client.base_url).hostname
-            if ip == 'localnpipe':
-                ip = 'localhost'
+            if ip == "localnpipe":
+                ip = "localhost"
 
         return ip, port
 
     def get_network_ip(self, network_settings):
-        networks = network_settings['Networks']
+        networks = network_settings["Networks"]
         if self.network_name not in networks:
             raise Exception(
                 "Unknown docker network '{network}'."
@@ -706,8 +770,9 @@ class DockerSpawner(Spawner):
                     network=self.network_name
                 )
             )
+
         network = networks[self.network_name]
-        ip = network['IPAddress']
+        ip = network["IPAddress"]
         return ip
 
     @gen.coroutine
@@ -717,34 +782,31 @@ class DockerSpawner(Spawner):
         Consider using pause/unpause when docker-py adds support
         """
         self.log.info(
-            "Stopping container %s (id: %s)",
-            self.container_name, self.object_id[:7])
-        yield self.docker('stop', self.object_id)
+            "Stopping %s %s (id: %s)", self.object_type, self.object_name, self.object_id[:7]
+        )
+        yield self.stop_object()
 
         if self.remove:
-            self.log.info(
-                "Removing container %s (id: %s)",
-                self.container_name, self.object_id[:7])
-            # remove the container, as well as any associated volumes
-            yield self.docker('remove_container', self.object_id, v=True)
+            yield self.remove_object()
 
         self.clear_state()
 
-    def _volumes_to_binds(self, volumes, binds, mode='rw'):
+    def _volumes_to_binds(self, volumes, binds, mode="rw"):
         """Extract the volume mount points from volumes property.
 
         Returns a dict of dict entries of the form::
 
             {'/host/dir': {'bind': '/guest/dir': 'mode': 'rw'}}
         """
+
         def _fmt(v):
             return self.format_volume_name(v, self)
 
         for k, v in volumes.items():
             m = mode
             if isinstance(v, dict):
-                if 'mode' in v:
-                    m = v['mode']
-                v = v['bind']
-            binds[_fmt(k)] = {'bind': _fmt(v), 'mode': m}
+                if "mode" in v:
+                    m = v["mode"]
+                v = v["bind"]
+            binds[_fmt(k)] = {"bind": _fmt(v), "mode": m}
         return binds

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -3,6 +3,7 @@ A Spawner for JupyterHub that runs each user's server in a separate docker conta
 """
 
 from concurrent.futures import ThreadPoolExecutor
+import os
 from pprint import pformat
 import string
 from textwrap import dedent
@@ -116,6 +117,14 @@ class DockerSpawner(Spawner):
         """,
         config=True,
     )
+    @default('host_ip')
+    def _default_host_ip(self):
+        docker_host = os.getenv('DOCKER_HOST')
+        if docker_host:
+            urlinfo = urlparse(docker_host)
+            if urlinfo.scheme == 'tcp':
+                return urlinfo.hostname
+        return '127.0.0.1'
 
     # unlike container_ip, container_port is the internal port
     # on which the server is bound.

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -28,6 +28,7 @@ from traitlets import (
 
 from .volumenamingstrategy import default_format_volume_name
 
+
 class UnicodeOrFalse(Unicode):
     info_text = 'a unicode string or False'
     def validate(self, obj, value):
@@ -38,7 +39,9 @@ class UnicodeOrFalse(Unicode):
 import jupyterhub
 _jupyterhub_xy = '%i.%i' % (jupyterhub.version_info[:2])
 
+
 class DockerSpawner(Spawner):
+    """A Spawner for JupyterHub that runs each user's server in a separate docker container"""
 
     _executor = None
     @property
@@ -257,8 +260,8 @@ class DockerSpawner(Spawner):
     extra_create_kwargs = Dict(config=True, help="Additional args to pass for container create")
     extra_host_config = Dict(config=True, help="Additional args to create_host_config for container create")
 
-    _container_safe_chars = set(string.ascii_letters + string.digits + '-')
-    _container_escape_char = '_'
+    _docker_safe_chars = set(string.ascii_letters + string.digits + '-')
+    _docker_escape_char = '_'
 
     hub_ip_connect = Unicode(
         config=True,
@@ -368,8 +371,8 @@ class DockerSpawner(Spawner):
     def escaped_name(self):
         if self._escaped_name is None:
             self._escaped_name = escape(self.user.name,
-                safe=self._container_safe_chars,
-                escape_char=self._container_escape_char,
+                safe=self._docker_safe_chars,
+                escape_char=self._docker_escape_char,
             )
         return self._escaped_name
 
@@ -668,5 +671,3 @@ class DockerSpawner(Spawner):
                 v = v['bind']
             binds[_fmt(k)] = {'bind': _fmt(v), 'mode': m}
         return binds
-
-

--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -122,8 +122,7 @@ class SwarmSpawner(DockerSpawner):
         if service_state['State'] == 'running':
             return None
         else:
-            return {k: pformat(v) for k, v in service.items()}
-
+            return pformat(service_state)
 
     @gen.coroutine
     def get_task(self):

--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -10,16 +10,16 @@ from docker.types import (
 )
 from docker.errors import APIError
 from tornado import gen
-from traitlets import Dict, Unicode, Bool, Int, Any, default, observe
+from traitlets import Dict, Unicode, default
 
 from .dockerspawner import DockerSpawner
-import jupyterhub
 
 
 class SwarmSpawner(DockerSpawner):
     """A Spawner for JupyterHub that runs each user's server in a separate docker service"""
 
     object_type = "service"
+    object_id_key = "ID"
 
     @property
     def service_id(self):
@@ -80,6 +80,9 @@ class SwarmSpawner(DockerSpawner):
         ),
     )
 
+    # container-removal cannot be disabled for services
+    remove = True
+
     @property
     def mount_driver_config(self):
         return DriverConfig(
@@ -109,35 +112,42 @@ class SwarmSpawner(DockerSpawner):
         """Check for my id in `docker ps`"""
         service = yield self.get_task()
         if not service:
-            self.log.warn("service not found")
+            self.log.warning("Service %s not found", self.service_name)
             return 0
 
-        service_state = service['Status']
+        service_state = service["Status"]
         self.log.debug(
-            "Service %s status: %s",
-            self.service_id[:7],
-            pformat(service_state),
+            "Service %s status: %s", self.service_id[:7], pformat(service_state)
         )
 
-        if service_state['State'] == 'running':
+        if service_state["State"] in {"running", "pending"}:
             return None
+
         else:
             return pformat(service_state)
 
     @gen.coroutine
     def get_task(self):
         self.log.debug("Getting task of service '%s'", self.service_name)
-        if self.get_service() is None:
+        if self.get_object() is None:
             return None
+
         try:
-            tasks = yield self.docker('tasks', filters={'service': self.service_name, 'desired-state': 'running'})
+            tasks = yield self.docker(
+                "tasks",
+                filters={"service": self.service_name, "desired-state": "running"},
+            )
             if len(tasks) == 0:
                 return None
+
             elif len(tasks) > 1:
-                # self.log.critical(pformat(tasks))
-                raise RuntimeError("Found more than one running notebook task for service '{}'".format(self.service_name))
+                raise RuntimeError(
+                    "Found more than one running notebook task for service '{}'".format(
+                        self.service_name
+                    )
+                )
+
             task = tasks[0]
-            # self.log.critical(pformat(task))
         except APIError as e:
             if e.response.status_code == 404:
                 self.log.info("Task for service '%s' is gone", self.service_name)
@@ -148,101 +158,70 @@ class SwarmSpawner(DockerSpawner):
         return task
 
     @gen.coroutine
-    def start(self):
+    def create_object(self):
         """Start the single-user server in a docker service."""
-        service = yield self.get_object()
-        if service and self.remove:
-            self.log.warning(
-                "Removing service that should have been cleaned up: %s (id: %s)",
-                self.service_name, self.service_id[:7])
-            # remove the service, as well as any associated volumes
-            yield self.docker('remove_service', self.service_id)
-            service = None
+        container_kwargs = dict(
+            image=self.image,
+            env=self.get_env(),
+            args=(yield self.get_command()),
+            mounts=self.mounts,
+        )
+        container_kwargs.update(self.extra_container_spec)
+        container_spec = ContainerSpec(**container_kwargs)
 
-        if service is None:
-            cmd = None
-            if self._user_set_cmd:
-                cmd = self.cmd
+        resources_kwargs = dict(
+            mem_limit=self.mem_limit,
+            mem_reservation=self.mem_guarantee,
+            cpu_limit=int(self.cpu_limit * 1e9) if self.cpu_limit else None,
+            cpu_reservation=int(
+                self.cpu_guarantee * 1e9
+            ) if self.cpu_guarantee else None,
+        )
+        resources_kwargs.update(self.extra_resources_spec)
+        resources_spec = Resources(**resources_kwargs)
 
-            # build the dictionary of keyword arguments for create_service
-            container_kwargs = dict(
-                image=self.image,
-                env=self.get_env(),
-                args=self.get_args(),
-                mounts=self.mounts,
-            )
-            if cmd:
-                container_kwargs['command'] = cmd
-            container_kwargs.update(self.extra_container_spec)
-            container_spec = ContainerSpec(**container_kwargs)
+        task_kwargs = dict(
+            container_spec=container_spec,
+            resources=resources_spec,
+            networks=[self.network_name] if self.network_name else [],
+        )
+        task_kwargs.update(self.extra_task_spec)
+        task_spec = TaskTemplate(**task_kwargs)
 
-            resources_kwargs = dict(
-                mem_limit=self.mem_limit,
-                mem_reservation=self.mem_guarantee,
-                cpu_limit=int(self.cpu_limit * 1e9) if self.cpu_limit else None,
-                cpu_reservation=int(self.cpu_guarantee * 1e9) if self.cpu_guarantee else None,
-            )
-            resources_kwargs.update(self.extra_resources_spec)
-            resources_spec = Resources(**resources_kwargs)
+        endpoint_kwargs = {}
+        if not self.use_internal_ip:
+            endpoint_kwargs["ports"] = {None: (self.port, "tcp")}
+        endpoint_kwargs.update(self.extra_endpoint_spec)
+        endpoint_spec = EndpointSpec(**endpoint_kwargs)
 
-            task_kwargs = dict(
-                container_spec=container_spec,
-                resources=resources_spec,
-                networks=[self.network_name] if self.network_name else [],
-            )
-            task_kwargs.update(self.extra_task_spec)
-            task_spec = TaskTemplate(**task_kwargs)
+        create_kwargs = dict(
+            task_template=task_spec, endpoint_spec=endpoint_spec, name=self.service_name
+        )
+        create_kwargs.update(self.extra_create_kwargs)
 
-            endpoint_kwargs = {}
-            endpoint_kwargs.update(self.extra_endpoint_spec)
-            endpoint_spec = EndpointSpec(**endpoint_kwargs)
+        return (yield self.docker("create_service", **create_kwargs))
 
-            create_kwargs = dict(
-                task_template=task_spec,
-                endpoint_spec=endpoint_spec,
-                name=self.service_name,
-            )
-            create_kwargs.update(self.extra_create_kwargs)
+    @gen.coroutine
+    def remove_object(self):
+        self.log.info("Removing %s %s", self.object_type, self.object_id)
+        # remove the container, as well as any associated volumes
+        yield self.docker("remove_" + self.object_type, self.object_id)
 
-            resp = yield self.docker('create_service', **create_kwargs)
+    @gen.coroutine
+    def start_object(self):
+        """Nothing to do here
 
-            self.object_id = resp['Id']
-            self.log.info(
-                "Created service '%s' (id: %s) from image %s",
-                self.service_name, self.service_id[:7], self.image)
+        There is no separate start action for services
+        """
+        pass
 
-        else:
-            self.log.info(
-                "Found existing service '%s' (id: %s)",
-                self.service_name, self.service_id[:7])
-            # Handle re-using API token.
-            # Get the API token from the environment variables
-            # of the running service:
-            for line in service['Config']['Env']:
-                if line.startswith(('JPY_API_TOKEN=', 'JUPYTERHUB_API_TOKEN=')):
-                    self.api_token = line.split('=', 1)[1]
-                    break
+    @gen.coroutine
+    def stop_object(self):
+        """Nothing to do here
 
-        # TODO: handle unpause
-        self.log.info(
-            "Starting service '%s' (id: %s)",
-            self.service_name, self.service_id[:7])
-
-        # build the dictionary of keyword arguments for start
-        start_kwargs = {}
-        start_kwargs.update(self.extra_start_kwargs)
-
-        # start the service
-        # TODO: service equivalent for this?
-        # yield self.docker('start', self.service_id, **start_kwargs)
-
-        ip, port = yield self.get_ip_and_port()
-        if jupyterhub.version_info < (0, 7):
-            # store on user for pre-jupyterhub-0.7:
-            self.user.server.ip = ip
-            self.user.server.port = port
-        # jupyterhub 0.7 prefers returning ip, port:
-        return (ip, port)
+        There is no separate stop action for services
+        """
+        pass
 
     @gen.coroutine
     def get_ip_and_port(self):
@@ -259,27 +238,26 @@ class SwarmSpawner(DockerSpawner):
         are correct, which depends on the route to the service
         and the port it opens.
         """
-        ip = self.service_name
-        port = self.port
+        if self.use_internal_ip:
+            ip = self.service_name
+            port = self.port
+        else:
+            # discover published ip, port
+            ip = self.host_ip
+            service = yield self.get_object()
+            for port_config in service["Endpoint"]["Ports"]:
+                if port_config.get("TargetPort") == self.port:
+                    port = port_config["PublishedPort"]
+                    break
+
+            else:
+                self.log.error(
+                    "Couldn't find PublishedPort for %s in %s",
+                    self.port,
+                    service["Endpoint"]["Ports"],
+                )
+                raise RuntimeError(
+                    "Couldn't identify port for service %s", self.service_name
+                )
 
         return ip, port
-
-    @gen.coroutine
-    def stop(self, now=False):
-        """Stop the service
-
-        Consider using pause/unpause when docker-py adds support
-        """
-        self.log.info(
-            "Stopping service %s (id: %s)",
-            self.service_name, self.service_id[:7])
-        yield self.docker('remove_service', self.service_id)
-
-        # if self.remove:
-        #     self.log.info(
-        #         "Removing service %s (id: %s)",
-        #         self.service_name, self.service_id[:7])
-        #     # remove the service, as well as any associated volumes
-        #     yield self.docker('remove_service', self.service_id, v=True)
-
-        self.clear_state()

--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -48,15 +48,6 @@ class SwarmSpawner(DockerSpawner):
         )
     )
 
-    # TODO: relevant anymore within swarmspawner?
-    remove_services = Bool(False, config=True, help="If True, delete services after they are stopped.")
-
-    @property
-    def will_resume(self):
-        # indicate that we will resume,
-        # so JupyterHub >= 0.7.1 won't cleanup our API token
-        return not self.remove_services
-
     @property
     def service_name(self):
         escaped_service_image = self.image.replace("/", "_")
@@ -214,7 +205,7 @@ class SwarmSpawner(DockerSpawner):
 
         """
         service = yield self.get_service()
-        if service and self.remove_services:
+        if service and self.remove:
             self.log.warning(
                 "Removing service that should have been cleaned up: %s (id: %s)",
                 self.service_name, self.service_id[:7])
@@ -344,7 +335,7 @@ class SwarmSpawner(DockerSpawner):
             self.service_name, self.service_id[:7])
         yield self.docker('remove_service', self.service_id)
 
-        # if self.remove_services:
+        # if self.remove:
         #     self.log.info(
         #         "Removing service %s (id: %s)",
         #         self.service_name, self.service_id[:7])

--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -31,6 +31,12 @@ class SwarmSpawner(DockerSpawner):
         """alias for object_name"""
         return self.object_name
 
+    @default("network_name")
+    def _default_network_name(self):
+        # no default network for swarm
+        # use internal networking by default
+        return ""
+
     extra_resources_spec = Dict(
         config=True,
         help="""

--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -2,18 +2,11 @@
 A Spawner for JupyterHub that runs each user's server in a separate docker service
 """
 
-import string
-import warnings
-from concurrent.futures import ThreadPoolExecutor
 from pprint import pformat
 from textwrap import dedent
 
-import docker
 from docker.types import ContainerSpec, TaskTemplate, Resources, EndpointSpec, Mount, DriverConfig
 from docker.errors import APIError
-from docker.utils import kwargs_from_env
-from escapism import escape
-from jupyterhub.spawner import Spawner
 from tornado import gen
 from traitlets import (
     Dict,
@@ -25,122 +18,13 @@ from traitlets import (
     observe,
 )
 
-from .volumenamingstrategy import default_format_volume_name
-
+from .dockerspawner import DockerSpawner
 import jupyterhub
 
-_jupyterhub_xy = '%i.%i' % (jupyterhub.version_info[:2])
 
-
-class SwarmSpawner(Spawner):
-    _executor = None
-
-    @property
-    def executor(self):
-        """single global executor"""
-        cls = self.__class__
-        if cls._executor is None:
-            cls._executor = ThreadPoolExecutor(1)
-        return cls._executor
-
-    _client = None
-
-    @property
-    def client(self):
-        """single global client instance"""
-        cls = self.__class__
-        if cls._client is None:
-            kwargs = {'version': 'auto'}
-            if self.tls_config:
-                kwargs['tls'] = docker.tls.TLSConfig(**self.tls_config)
-            kwargs.update(kwargs_from_env())
-            kwargs.update(self.client_kwargs)
-            client = docker.APIClient(**kwargs)
-            cls._client = client
-        return cls._client
-
-    # notice when user has set the command
-    # default command is that of the service,
-    # but user can override it via config
-    _user_set_cmd = False
-
-    @observe('cmd')
-    def _cmd_changed(self, change):
-        self._user_set_cmd = True
-
+class SwarmSpawner(DockerSpawner):
+    """A Spawner for JupyterHub that runs each user's server in a separate docker service"""
     service_id = Unicode()
-
-    # deprecate misleading service_ip, since
-    # it is not the ip in the service,
-    # but the host ip of the port forwarded to the service
-    # when use_internal_ip is False
-    service_ip = Unicode('127.0.0.1', config=True)
-
-    @observe('service_ip')
-    def _service_ip_deprecated(self, change):
-        self.log.warning(
-            "SwarmSpawner.service_ip is deprecated in dockerspawner-0.9."
-            "  Use SwarmSpawner.host_ip to specify the host ip that is forwarded to the service"
-        )
-        self.host_ip = change.new
-
-    host_ip = Unicode('127.0.0.1',
-                      help="""The ip address on the host on which to expose the service's port
-
-        Typically 127.0.0.1, but can be public interfaces as well
-        in cases where the Hub and/or proxy are on different machines
-        from the user services.
-
-        Only used when use_internal_ip = False.
-        """
-                      )
-
-    # unlike service_ip, service_port is the internal port
-    # on which the server is bound.
-    service_port = Int(8888, min=1, max=65535, config=True)
-
-    @observe('service_port')
-    def _service_port_changed(self, change):
-        self.log.warning(
-            "SwarmSpawner.service_port is deprecated in dockerspawner 0.9."
-            "  Use SwarmSpawner.port"
-        )
-        self.port = change.new
-
-    # fix default port to 8888, used in the service
-    @default('port')
-    def _port_default(self):
-        return 8888
-
-    # default to listening on all-interfaces in the service
-    @default('ip')
-    def _ip_default(self):
-        return '0.0.0.0'
-
-    service_image = Unicode("jupyterhub/singleuser:%s" % _jupyterhub_xy, config=True)
-
-    @observe('service_image')
-    def _service_image_changed(self, change):
-        self.log.warning(
-            "SwarmSpawner.service_image is deprecated in dockerspawner 0.9."
-            "  Use SwarmSpawner.image"
-        )
-        self.image = change.new
-
-    image = Unicode("jupyterhub/singleuser:%s" % _jupyterhub_xy, config=True,
-                    help="""The image to use for single-user servers.
-
-        This image should have the same version of jupyterhub as
-        the Hub itself installed.
-
-        If the default command of the image does not launch
-        jupyterhub-singleuser, set `c.Spawner.cmd` to
-        launch jupyterhub-singleuser, e.g.
-
-        Any of the jupyter docker-stacks should work without additional config,
-        as long as the version of jupyterhub in the image is compatible.
-        """
-                    )
 
     service_prefix = Unicode(
         "jupyter",
@@ -164,89 +48,6 @@ class SwarmSpawner(Spawner):
         )
     )
 
-    client_kwargs = Dict(
-        config=True,
-        help="Extra keyword arguments to pass to the docker.Client constructor.",
-    )
-
-    volumes = Dict(
-        config=True,
-        help=dedent(
-            """
-            Map from host file/directory to service (guest) file/directory
-            mount point and (optionally) a mode. When specifying the
-            guest mount point (bind) for the volume, you may use a
-            dict or str. If a str, then the volume will default to a
-            read-write (mode="rw"). With a dict, the bind is
-            identified by "bind" and the "mode" may be one of "rw"
-            (default), "ro" (read-only), "z" (public/shared SELinux
-            volume label), and "Z" (private/unshared SELinux volume
-            label).
-
-            If format_volume_name is not set,
-            default_format_volume_name is used for naming volumes.
-            In this case, if you use {username} in either the host or guest
-            file/directory path, it will be replaced with the current
-            user's name.
-            """
-        )
-    )
-
-    read_only_volumes = Dict(
-        config=True,
-        help=dedent(
-            """
-            Map from host file/directory to service file/directory.
-            Volumes specified here will be read-only in the service.
-
-            If format_volume_name is not set,
-            default_format_volume_name is used for naming volumes.
-            In this case, if you use {username} in either the host or guest
-            file/directory path, it will be replaced with the current
-            user's name.
-            """
-        )
-    )
-
-    format_volume_name = Any(
-        help="""Any callable that accepts a string template and a SwarmSpawner instance as parameters in that order and returns a string.
-
-        Reusable implementations should go in dockerspawner.VolumeNamingStrategy, tests should go in ...
-        """
-    ).tag(config=True)
-
-    def default_format_volume_name(template, spawner):
-        return template.format(username=spawner.user.name)
-
-    @default('format_volume_name')
-    def _get_default_format_volume_name(self):
-        return default_format_volume_name
-
-    use_docker_client_env = Bool(True, config=True,
-                                 help="DEPRECATED. Docker env variables are always used if present.")
-
-    @observe('use_docker_client_env')
-    def _client_env_changed(self):
-        self.log.warning("SwarmSpawner.use_docker_client_env is deprecated and ignored."
-                         "  Docker environment variables are always used if defined.")
-
-    tls_config = Dict(config=True,
-                      help="""Arguments to pass to docker TLS configuration.
-        
-        See docker.client.TLSConfig constructor for options.
-        """
-                      )
-    tls = tls_verify = tls_ca = tls_cert = \
-        tls_key = tls_assert_hostname = Any(config=True,
-                                            help="""DEPRECATED. Use SwarmSpawner.tls_config dict to set any TLS options."""
-                                            )
-
-    @observe('tls', 'tls_verify', 'tls_ca', 'tls_cert', 'tls_key', 'tls_assert_hostname')
-    def _tls_changed(self, change):
-        self.log.warning("%s config ignored, use %s.tls_config dict to set full TLS configuration.",
-                         change.name, self.__class__.__name__,
-                         )
-
     # TODO: relevant anymore within swarmspawner?
     remove_services = Bool(False, config=True, help="If True, delete services after they are stopped.")
 
@@ -256,118 +57,13 @@ class SwarmSpawner(Spawner):
         # so JupyterHub >= 0.7.1 won't cleanup our API token
         return not self.remove_services
 
-    extra_create_kwargs = Dict(config=True, help="Additional args to pass for service create")
-    extra_start_kwargs = Dict(config=True, help="Additional args to pass for service start")
-    extra_host_config = Dict(config=True, help="Additional args to create_host_config for service create")
-
-    _service_safe_chars = set(string.ascii_letters + string.digits + '-')
-    _service_escape_char = '_'
-
-    hub_ip_connect = Unicode(
-        config=True,
-        help=dedent(
-            """
-            If set, SwarmSpawner will configure the services to use
-            the specified IP to connect the hub api.  This is useful
-            when the hub_api is bound to listen on all ports or is
-            running inside of a service.
-            """
-        )
-    )
-
-    @observe('hub_ip_connect')
-    def _ip_connect_changed(self, change):
-        if jupyterhub.version_info >= (0, 8):
-            warnings.warn(
-                "SwarmSpawner.hub_ip_connect is no longer needed with JupyterHub 0.8."
-                "  Use JupyterHub.hub_connect_ip instead.",
-                DeprecationWarning,
-            )
-
-    # TODO: can this be anything but True in swarmspawner?
-    use_internal_ip = Bool(False,
-                           config=True,
-                           help=dedent(
-                               """
-                               Enable the usage of the internal docker ip. This is useful if you are running
-                               jupyterhub (as a service) and the user services within the same docker network.
-                               E.g. by mounting the docker socket of the host into the jupyterhub service.
-                               Default is True if using a docker network, False if bridge or host networking is used.
-                               """
-                           )
-                           )
-
-    @default('use_internal_ip')
-    def _default_use_ip(self):
-        # setting network_name to something other than bridge or host implies use_internal_ip
-        if self.network_name not in {'bridge', 'host'}:
-            return True
-        else:
-            return False
-
-    links = Dict(
-        config=True,
-        help=dedent(
-            """
-            Specify docker link mapping to add to the service, e.g.
-
-                links = {'jupyterhub': 'jupyterhub'}
-
-            If the Hub is running in a Docker service,
-            this can simplify routing because all traffic will be using docker hostnames.
-            """
-        )
-    )
-
-    network_name = Unicode(
-        "bridge",
-        config=True,
-        help=dedent(
-            """
-            Run the services on this docker network.
-            If it is an internal docker network, the Hub should be on the same network,
-            as internal docker IP addresses will be used.
-            For bridge networking, external ports will be bound.
-            """
-        )
-    )
-
     @property
-    def tls_client(self):
-        """A tuple consisting of the TLS client certificate and key if they
-        have been provided, otherwise None.
-
-        """
-        if self.tls_cert and self.tls_key:
-            return (self.tls_cert, self.tls_key)
-        return None
-
-    @property
-    def volume_mount_points(self):
-        """
-        Volumes are declared in docker-py in two stages.  First, you declare
-        all the locations where you're going to mount volumes when you call
-        create_service.
-        Returns a sorted list of all the values in self.volumes or
-        self.read_only_volumes.
-        """
-        return sorted([value['bind'] for value in self.volume_binds.values()])
-
-    @property
-    def volume_binds(self):
-        """
-        The second half of declaring a volume with docker-py happens when you
-        actually call start().  The required format is a dict of dicts that
-        looks like:
-
-        {
-            host_location: {'bind': service_location, 'mode': 'rw'}
-        }
-        mode may be 'ro', 'rw', 'z', or 'Z'.
-
-        """
-        binds = self._volumes_to_binds(self.volumes, {})
-        return self._volumes_to_binds(self.read_only_volumes, binds, mode='ro')
+    def service_name(self):
+        escaped_service_image = self.image.replace("/", "_")
+        server_name = getattr(self, 'name', '')
+        d = {'username': self.escaped_name, 'imagename': escaped_service_image, 'servername': server_name,
+             'prefix': self.service_prefix}
+        return self.service_name_template.format(**d)
 
     volume_driver = Unicode(
         "",
@@ -407,25 +103,6 @@ class SwarmSpawner(Spawner):
         else:
             return []
 
-    _escaped_name = None
-
-    @property
-    def escaped_name(self):
-        if self._escaped_name is None:
-            self._escaped_name = escape(self.user.name,
-                                        safe=self._service_safe_chars,
-                                        escape_char=self._service_escape_char,
-                                        )
-        return self._escaped_name
-
-    @property
-    def service_name(self):
-        escaped_service_image = self.image.replace("/", "_")
-        server_name = getattr(self, 'name', '')
-        d = {'username': self.escaped_name, 'imagename': escaped_service_image, 'servername': server_name,
-             'prefix': self.service_prefix}
-        return self.service_name_template.format(**d)
-
     def load_state(self, state):
         super(SwarmSpawner, self).load_state(state)
         self.service_id = state.get('service_id', '')
@@ -435,46 +112,6 @@ class SwarmSpawner(Spawner):
         if self.service_id:
             state['service_id'] = self.service_id
         return state
-
-    def _public_hub_api_url(self):
-        proto, path = self.hub.api_url.split('://', 1)
-        ip, rest = path.split(':', 1)
-        return '{proto}://{ip}:{rest}'.format(
-            proto=proto,
-            ip=self.hub_ip_connect,
-            rest=rest
-        )
-
-    def _env_keep_default(self):
-        """Don't inherit any env from the parent process"""
-        return []
-
-    def get_args(self):
-        args = super().get_args()
-        if self.hub_ip_connect:
-            # JupyterHub 0.7 specifies --hub-api-url
-            # on the command-line, which is hard to update
-            for idx, arg in enumerate(list(args)):
-                if arg.startswith('--hub-api-url='):
-                    args.pop(idx)
-                    break
-            args.append('--hub-api-url=%s' % self._public_hub_api_url())
-        return args
-
-    def _docker(self, method, *args, **kwargs):
-        """wrapper for calling docker methods
-
-        to be passed to ThreadPoolExecutor
-        """
-        m = getattr(self.client, method)
-        return m(*args, **kwargs)
-
-    def docker(self, method, *args, **kwargs):
-        """Call a docker method in a background thread
-
-        returns a Future
-        """
-        return self.executor.submit(self._docker, method, *args, **kwargs)
 
     @gen.coroutine
     def poll(self):
@@ -715,23 +352,3 @@ class SwarmSpawner(Spawner):
         #     yield self.docker('remove_service', self.service_id, v=True)
 
         self.clear_state()
-
-    def _volumes_to_binds(self, volumes, binds, mode='rw'):
-        """Extract the volume mount points from volumes property.
-
-        Returns a dict of dict entries of the form::
-
-            {'/host/dir': {'bind': '/guest/dir': 'mode': 'rw'}}
-        """
-
-        def _fmt(v):
-            return self.format_volume_name(v, self)
-
-        for k, v in volumes.items():
-            m = mode
-            if isinstance(v, dict):
-                if 'mode' in v:
-                    m = v['mode']
-                v = v['bind']
-            binds[_fmt(k)] = {'bind': _fmt(v), 'mode': m}
-        return binds

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+"""pytest config for dockerspawner tests"""
+
+from unittest import mock
+
+from docker import from_env as docker_from_env
+import pytest
+
+from jupyterhub.tests.mocking import MockHub
+
+# import base jupyterhub fixtures
+from jupyterhub.tests.conftest import app, io_loop  # noqa
+from dockerspawner import DockerSpawner
+
+# make Hub connectable from docker by default
+MockHub.hub_ip = "0.0.0.0"
+
+
+@pytest.fixture
+def dockerspawner(app):
+    """Configure JupyterHub to use DockerSpawner"""
+    app.config.DockerSpawner.prefix = "dockerspawner-test"
+    # app.config.DockerSpawner.remove = True
+    with mock.patch.dict(app.tornado_settings, {"spawner_class": DockerSpawner}):
+        yield
+
+
+@pytest.fixture(autouse=True, scope="session")
+def docker():
+    """Fixture to return a connected docker client
+
+    cleans up any containers we leave in docker
+    """
+    d = docker_from_env()
+    try:
+        yield d
+
+    finally:
+        # cleanup our containers
+        for c in d.containers.list(all=True):
+            if c.name.startswith("dockerspawner-test"):
+                c.stop()
+                c.remove()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,5 +43,4 @@ def docker():
 
         for c in d.services.list():
             if c.name.startswith("dockerspawner-test"):
-                c.stop()
                 c.remove()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,3 +40,8 @@ def docker():
             if c.name.startswith("dockerspawner-test"):
                 c.stop()
                 c.remove()
+
+        for c in d.services.list():
+            if c.name.startswith("dockerspawner-test"):
+                c.stop()
+                c.remove()

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -1,0 +1,32 @@
+"""Tests for DockerSpawner class"""
+
+import pytest
+from jupyterhub.tests.test_api import add_user, api_request
+from jupyterhub.tests.mocking import public_url
+from jupyterhub.tests.utils import async_requests
+from jupyterhub.utils import url_path_join
+
+from dockerspawner import DockerSpawner
+
+pytestmark = pytest.mark.usefixtures("dockerspawner")
+
+
+@pytest.mark.gen_test
+def test_start_stop(app):
+    name = "has@"
+    add_user(app.db, app, name=name)
+    user = app.users[name]
+    assert isinstance(user.spawner, DockerSpawner)
+    token = user.new_api_token()
+    # start the server
+    r = yield api_request(app, "users", name, "server", method="post")
+    while r.status_code == 202:
+        # request again
+        r = yield api_request(app, "users", name, "server", method="post")
+    assert r.status_code == 201, r.text
+    url = url_path_join(public_url(app, user), "api/status")
+    r = yield async_requests.get(url, headers={"Authorization": "token %s" % token})
+    assert r.url == url
+    r.raise_for_status()
+    print(r.text)
+    assert "kernels" in r.json()

--- a/tests/test_swarmspawner.py
+++ b/tests/test_swarmspawner.py
@@ -1,0 +1,46 @@
+"""Tests for SwarmSpawner"""
+
+from unittest import mock
+
+import pytest
+from jupyterhub.tests.test_api import add_user, api_request
+from jupyterhub.tests.mocking import public_url
+from jupyterhub.tests.utils import async_requests
+from jupyterhub.utils import url_path_join
+
+from dockerspawner import SwarmSpawner
+
+pytestmark = pytest.mark.usefixtures("swarmspawner")
+
+
+@pytest.fixture
+def swarmspawner(app):
+    """Configure JupyterHub to use DockerSpawner"""
+    app.config.SwarmSpawner.prefix = "dockerspawner-test"
+    with mock.patch.dict(
+        app.tornado_settings, {"spawner_class": SwarmSpawner}
+    ), mock.patch.dict(
+        app.config.SwarmSpawner, {"network_name": "bridge"}
+    ):
+        yield
+
+
+@pytest.mark.gen_test
+def test_start_stop(app):
+    name = "somebody"
+    add_user(app.db, app, name=name)
+    user = app.users[name]
+    assert isinstance(user.spawner, SwarmSpawner)
+    token = user.new_api_token()
+    # start the server
+    r = yield api_request(app, "users", name, "server", method="post")
+    while r.status_code == 202:
+        # request again
+        r = yield api_request(app, "users", name, "server", method="post")
+    assert r.status_code == 201, r.text
+    url = url_path_join(public_url(app, user), "api/status")
+    r = yield async_requests.get(url, headers={"Authorization": "token %s" % token})
+    assert r.url == url
+    r.raise_for_status()
+    print(r.text)
+    assert "kernels" in r.json()

--- a/tests/test_systemuserspawner.py
+++ b/tests/test_systemuserspawner.py
@@ -1,0 +1,45 @@
+"""Tests for SwarmSpawner"""
+
+from getpass import getuser
+from unittest import mock
+
+import pytest
+from jupyterhub.tests.test_api import add_user, api_request
+from jupyterhub.tests.mocking import public_url
+from jupyterhub.tests.utils import async_requests
+from jupyterhub.utils import url_path_join
+
+from dockerspawner import SystemUserSpawner
+
+pytestmark = pytest.mark.usefixtures("systemuserspawner")
+
+
+@pytest.fixture
+def systemuserspawner(app):
+    """Configure JupyterHub to use DockerSpawner"""
+    app.config.SwarmSpawner.prefix = "dockerspawner-test"
+    with mock.patch.dict(
+        app.tornado_settings, {"spawner_class": SystemUserSpawner}
+    ):
+        yield
+
+
+@pytest.mark.gen_test
+def test_start_stop(app):
+    name = getuser()
+    add_user(app.db, app, name=name)
+    user = app.users[name]
+    assert isinstance(user.spawner, SystemUserSpawner)
+    token = user.new_api_token()
+    # start the server
+    r = yield api_request(app, "users", name, "server", method="post")
+    while r.status_code == 202:
+        # request again
+        r = yield api_request(app, "users", name, "server", method="post")
+    assert r.status_code == 201, r.text
+    url = url_path_join(public_url(app, user), "api/status")
+    r = yield async_requests.get(url, headers={"Authorization": "token %s" % token})
+    assert r.url == url
+    r.raise_for_status()
+    print(r.text)
+    assert "kernels" in r.json()

--- a/tests/volumes_test.py
+++ b/tests/volumes_test.py
@@ -9,55 +9,68 @@ from traitlets.config import LoggingConfigurable
 
 def test_binds(monkeypatch):
     import jupyterhub
+
     monkeypatch.setattr("jupyterhub.spawner.Spawner", _MockSpawner)
     from dockerspawner.dockerspawner import DockerSpawner
+
     d = DockerSpawner()
-    d.user = types.SimpleNamespace(name='xyz')
-    d.volumes = {
-        'a': 'b',
-        'c': {'bind': 'd', 'mode': 'Z'},
-    }
-    assert d.volume_binds == {
-        'a': {'bind': 'b', 'mode': 'rw'},
-        'c': {'bind': 'd', 'mode': 'Z'},
-    }
-    d.volumes = {'a': 'b', 'c': 'd', 'e': 'f'}
-    assert d.volume_mount_points == ['b', 'd', 'f']
-    d.volumes = {'/nfs/{username}': {'bind': '/home/{username}', 'mode': 'z'}}
-    assert d.volume_binds == {'/nfs/xyz': {'bind': '/home/xyz', 'mode': 'z'}}
-    assert d.volume_mount_points == ['/home/xyz']
+    d.user = types.SimpleNamespace(name="xyz")
+    d.volumes = {"a": "b", "c": {"bind": "d", "mode": "Z"}}
+    assert (
+        d.volume_binds
+        == {"a": {"bind": "b", "mode": "rw"}, "c": {"bind": "d", "mode": "Z"}}
+    )
+    d.volumes = {"a": "b", "c": "d", "e": "f"}
+    assert d.volume_mount_points == ["b", "d", "f"]
+    d.volumes = {"/nfs/{username}": {"bind": "/home/{username}", "mode": "z"}}
+    assert d.volume_binds == {"/nfs/xyz": {"bind": "/home/xyz", "mode": "z"}}
+    assert d.volume_mount_points == ["/home/xyz"]
+
 
 def test_volume_naming_configuration(monkeypatch):
     from dockerspawner.dockerspawner import DockerSpawner
+
     d = DockerSpawner()
-    d.user = types.SimpleNamespace(name='joe')
-    d.volumes = {'data/{username}': {'bind': '/home/{username}', 'mode': 'z'}}
+    d.user = types.SimpleNamespace(name="joe")
+    d.volumes = {"data/{username}": {"bind": "/home/{username}", "mode": "z"}}
 
     def test_format(label_template, spawner):
         return "THIS IS A TEST"
 
     d.format_volume_name = test_format
-    assert d.volume_binds == {'THIS IS A TEST':{'bind': 'THIS IS A TEST', 'mode': 'z'}}
-    assert d.volume_mount_points == ['THIS IS A TEST']
+    assert d.volume_binds == {"THIS IS A TEST": {"bind": "THIS IS A TEST", "mode": "z"}}
+    assert d.volume_mount_points == ["THIS IS A TEST"]
+
 
 def test_default_format_volume_name(monkeypatch):
     from dockerspawner.dockerspawner import DockerSpawner
+
     d = DockerSpawner()
-    d.user = types.SimpleNamespace(name='user@email.com')
-    d.volumes = {'data/{username}': {'bind': '/home/{username}', 'mode': 'z'}}
-    assert d.volume_binds == {'data/user@email.com':{'bind': '/home/user@email.com', 'mode': 'z'}}
-    assert d.volume_mount_points == ['/home/user@email.com']
+    d.user = types.SimpleNamespace(name="user@email.com")
+    d.volumes = {"data/{username}": {"bind": "/home/{username}", "mode": "z"}}
+    assert (
+        d.volume_binds
+        == {"data/user@email.com": {"bind": "/home/user@email.com", "mode": "z"}}
+    )
+    assert d.volume_mount_points == ["/home/user@email.com"]
+
 
 def test_escaped_format_volume_name(monkeypatch):
     import dockerspawner
     from dockerspawner import DockerSpawner
 
     d = DockerSpawner()
-    d.user = types.SimpleNamespace(name='user@email.com')
-    d.volumes = {'data/{username}': {'bind': '/home/{username}', 'mode': 'z'}}
+    d.user = types.SimpleNamespace(name="user@email.com")
+    d.volumes = {"data/{username}": {"bind": "/home/{username}", "mode": "z"}}
     d.format_volume_name = dockerspawner.volumenamingstrategy.escaped_format_volume_name
-    assert d.volume_binds == {'data/user_40email_2Ecom':{'bind': '/home/user_40email_2Ecom', 'mode': 'z'}}
-    assert d.volume_mount_points == ['/home/user_40email_2Ecom']
+    assert (
+        d.volume_binds
+        == {
+            "data/user_40email_2Ecom": {"bind": "/home/user_40email_2Ecom", "mode": "z"}
+        }
+    )
+    assert d.volume_mount_points == ["/home/user_40email_2Ecom"]
+
 
 class _MockSpawner(LoggingConfigurable):
     pass


### PR DESCRIPTION
This greatly reduces the complexity and duplication of the SwarmSpawner, which has config almost entirely shared with DockerSpawner.

Methods factored-out where the two differ:

- get_object (inspect_container|service)
- create_object (docker create, service create)
- start_object (docker start, no-op)
- stop_object (docker stop, no-op)
- remove_object (docker remove, service rm)

Additional fixes in SwarmSpawner:

- Fix ip/port resolution for exposed swarm ports
- Dedicated config for overriding Task/Endpoint/Container/Resources, rather than overloading `extra_create_kwargs`, which is by definition extra kwargs to be passed to create and only create.

Before merging this, I'll make sure there are basic tests for these Spawners running on Travis