### PR TITLE
Fix object names for google oauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ htmlcov/
 .tox/
 .coverage
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 
@@ -61,6 +62,7 @@ env
 venv
 oauthenticator.py
 jupyterhub.sqlite
+jupyterhub_cookie_secret
 src
 
 # Pycharm

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ userlist
 ssl.cert
 ssl.key
 env
+venv
 oauthenticator.py
 jupyterhub.sqlite
 src

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -458,7 +458,7 @@ class DockerSpawner(Spawner):
                 self.user.name,
                 safe=self._docker_safe_chars,
                 escape_char=self._docker_escape_char,
-            )
+            ).lower()
         return self._escaped_name
 
     object_id = Unicode(allow_none=True)

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -264,7 +264,7 @@ class DockerSpawner(Spawner):
     )
 
     def default_format_volume_name(template, spawner):
-        return template.format(username=spawner.user.name)
+        return template.format(username=spawner.escaped_name)
 
     @default("format_volume_name")
     def _get_default_format_volume_name(self):

--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -91,6 +91,9 @@ class SwarmSpawner(DockerSpawner):
 
     @property
     def mount_driver_config(self):
+        if not self.volume_driver:
+            return None
+
         return DriverConfig(
             name=self.volume_driver, options=self.volume_driver_options or None
         )

--- a/tests/volumes_test.py
+++ b/tests/volumes_test.py
@@ -66,10 +66,10 @@ def test_escaped_format_volume_name(monkeypatch):
     assert (
         d.volume_binds
         == {
-            "data/user_40email_2Ecom": {"bind": "/home/user_40email_2Ecom", "mode": "z"}
+            "data/user_40email_2ecom": {"bind": "/home/user_40email_2ecom", "mode": "z"}
         }
     )
-    assert d.volume_mount_points == ["/home/user_40email_2Ecom"]
+    assert d.volume_mount_points == ["/home/user_40email_2ecom"]
 
 
 class _MockSpawner(LoggingConfigurable):


### PR DESCRIPTION
There's a problem with docker resource names while using Google OAuth.

Google returns username as `username@gmail.com`. then `escape` converts it to `username_40gmail_2Ecom`.
But for the container_name, volumes it becomes with lower case and will not match with original.
So the container cannot be found by jupyterhub proxy.