### PR TITLE
add DockerSpawner.pull_policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,13 @@ install:
   - pip freeze
 script:
   - pyflakes dockerspawner
+  - |
+    # pre-pull images to avoid long wait times in tests
+    for v in 0.8 0.9; do
+      docker pull jupyterhub/singleuser:$v
+      # preserve the layers with a different tag
+      docker tag jupyterhub/singleuser:$v jupyterhub/singleuser:${v}-cache
+      # untag so that pull actions are still required
+      docker rmi jupyterhub/singleuser:$v
+    done
   - travis_retry py.test --cov dockerspawner tests -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,4 @@ install:
   - pip freeze
 script:
   - pyflakes dockerspawner
-  - docker pull jupyterhub/singleuser:0.8
-  - docker pull jupyterhub/singleuser:0.9
   - travis_retry py.test --cov dockerspawner tests -v

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -20,6 +20,7 @@ from jupyterhub.spawner import Spawner
 from traitlets import (
     Any,
     Bool,
+    CaselessStrEnum,
     Dict,
     List,
     Int,
@@ -265,6 +266,20 @@ class DockerSpawner(Spawner):
         if 'image' in formdata:
             options['image'] = formdata['image'][0]
         return options
+
+    pull_policy = CaselessStrEnum(
+        ["always", "ifnotpresent", "never"],
+        default_value="ifnotpresent",
+        config=True,
+        help="""The policy for pulling the user docker image.
+
+        Choices:
+
+        - ifnotpresent: pull if the image is not already present (default)
+        - always: always pull the image to check for updates, even if it is present
+        - never: never perform a pull
+        """
+    )
 
     container_prefix = Unicode(config=True, help="DEPRECATED in 0.10. Use prefix")
 
@@ -759,6 +774,41 @@ class DockerSpawner(Spawner):
         """
         return self.docker("stop", self.container_id)
 
+
+    @gen.coroutine
+    def pull_image(self, image):
+        """Pull the image, if needed
+
+        - pulls it unconditionally if pull_policy == 'always'
+        - otherwise, checks if it exists, and
+          - raises if pull_policy == 'never'
+          - pulls if pull_policy == 'ifnotpresent'
+        """
+        # docker wants to split repo:tag
+        if ':' in image:
+            repo, tag = image.split(':', 1)
+        else:
+            repo = image
+            tag = 'latest'
+
+        if self.pull_policy.lower() == 'always':
+            # always pull
+            self.log.info("pulling %s", image)
+            yield self.docker('pull', repo, tag)
+            # done
+            return
+        try:
+            # check if the image is present
+            _image = yield self.docker('inspect_image', image)
+        except docker.errors.NotFound:
+            if self.pull_policy == "never":
+                # never pull, raise because there is no such image
+                raise
+            elif self.pull_policy == "ifnotpresent":
+                # not present, pull it for the first time
+                self.log.info("pulling image %s", image)
+                yield self.docker('pull', repo, tag)
+
     @gen.coroutine
     def start(self, image=None, extra_create_kwargs=None, extra_host_config=None):
         """Start the single-user server in a docker container.
@@ -786,6 +836,7 @@ class DockerSpawner(Spawner):
             self.extra_host_config.update(extra_host_config)
 
         image = self.image
+        yield self.pull_image(image)
 
         obj = yield self.get_object()
         if obj and self.remove:

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -696,7 +696,13 @@ class DockerSpawner(Spawner):
     def remove_object(self):
         self.log.info("Removing %s %s", self.object_type, self.object_id)
         # remove the container, as well as any associated volumes
-        yield self.docker("remove_" + self.object_type, self.object_id, v=True)
+        try:
+            yield self.docker("remove_" + self.object_type, self.object_id, v=True)
+        except docker.errors.APIError as e:
+            if e.status_code == 409:
+                self.log.debug("Already removing %s: %s", self.object_type, self.object_id)
+            else:
+                raise
 
     @gen.coroutine
     def check_image_whitelist(self, image):

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -714,13 +714,6 @@ class DockerSpawner(Spawner):
     @gen.coroutine
     def create_object(self):
         """Create the container/service object"""
-        # image priority:
-        # 1. user options (from spawn options form)
-        # 2. self.image from config
-        image_option = self.user_options.get('image')
-        if image_option:
-            # save choice in self.image
-            self.image = yield self.check_image_whitelist(image_option)
 
         create_kwargs = dict(
             image=self.image,
@@ -834,6 +827,14 @@ class DockerSpawner(Spawner):
                 "Specifying extra_host_config via .start args is deprecated"
             )
             self.extra_host_config.update(extra_host_config)
+
+        # image priority:
+        # 1. user options (from spawn options form)
+        # 2. self.image from config
+        image_option = self.user_options.get('image')
+        if image_option:
+            # save choice in self.image
+            self.image = yield self.check_image_whitelist(image_option)
 
         image = self.image
         yield self.pull_image(image)

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -798,7 +798,7 @@ class DockerSpawner(Spawner):
             return
         try:
             # check if the image is present
-            _image = yield self.docker('inspect_image', image)
+            yield self.docker('inspect_image', image)
         except docker.errors.NotFound:
             if self.pull_policy == "never":
                 # never pull, raise because there is no such image

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -15,7 +15,7 @@ from dockerspawner import DockerSpawner
 pytestmark = pytest.mark.usefixtures("dockerspawner")
 
 
-@pytest.mark.gen_test
+@pytest.mark.gen_test(timeout=90)
 def test_start_stop(app):
     name = "has@"
     add_user(app.db, app, name=name)
@@ -37,7 +37,7 @@ def test_start_stop(app):
     assert "kernels" in r.json()
 
 
-@pytest.mark.gen_test
+@pytest.mark.gen_test(timeout=90)
 @pytest.mark.parametrize("image", ["0.8", "0.9", "nomatch"])
 def test_image_whitelist(app, image):
     name = "checker"
@@ -73,7 +73,7 @@ def test_image_whitelist(app, image):
     r.raise_for_status()
 
 
-@pytest.mark.gen_test
+@pytest.mark.gen_test(timeout=90)
 def test_image_pull_policy(app):
     name = "gumby"
     add_user(app.db, app, name=name)

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -88,7 +88,7 @@ def test_image_pull_policy(app):
     try:
         yield spawner.docker("remove_image", "{}:{}".format(repo, tag))
     except docker.errors.ImageNotFound:
-        raise
+        pass
 
     spawner.pull_policy = "ifnotpresent"
     image = "{}:{}".format(repo, tag)

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -8,6 +8,7 @@ from jupyterhub.tests.test_api import add_user, api_request
 from jupyterhub.tests.mocking import public_url
 from jupyterhub.tests.utils import async_requests
 from jupyterhub.utils import url_path_join
+from tornado import gen
 
 from dockerspawner import DockerSpawner
 
@@ -26,6 +27,7 @@ def test_start_stop(app):
     while r.status_code == 202:
         # request again
         r = yield api_request(app, "users", name, "server", method="post")
+        yield gen.sleep(0.1)
     assert r.status_code == 201, r.text
     url = url_path_join(public_url(app, user), "api/status")
     r = yield async_requests.get(url, headers={"Authorization": "token %s" % token})
@@ -59,6 +61,7 @@ def test_image_whitelist(app, image):
     while r.status_code == 202:
         # request again
         r = yield api_request(app, "users", name, "server", method="post")
+        yield gen.sleep(0.1)
     assert r.status_code == 201, r.text
     url = url_path_join(public_url(app, user), "api/status")
     r = yield async_requests.get(url, headers={"Authorization": "token %s" % token})

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -2,8 +2,8 @@
 
 import json
 
+import docker
 import pytest
-
 from jupyterhub.tests.test_api import add_user, api_request
 from jupyterhub.tests.mocking import public_url
 from jupyterhub.tests.utils import async_requests
@@ -68,3 +68,54 @@ def test_image_whitelist(app, image):
         app, "users", name, "server", method="delete",
     )
     r.raise_for_status()
+
+
+@pytest.mark.gen_test
+def test_image_pull_policy(app):
+    name = "gumby"
+    add_user(app.db, app, name=name)
+    user = app.users[name]
+    assert isinstance(user.spawner, DockerSpawner)
+    spawner = user.spawners[""]
+    spawner.image = "jupyterhub/doesntexist:nosuchtag"
+    with pytest.raises(docker.errors.NotFound):
+        spawner.image_pull_policy = "never"
+        yield spawner.pull_image(spawner.image)
+
+    repo = "busybox"
+    tag = "1.29.1"  # a version that's definitely not latest
+    # ensure image isn't present
+    try:
+        yield spawner.docker("remove_image", "{}:{}".format(repo, tag))
+    except docker.errors.ImageNotFound:
+        raise
+
+    spawner.pull_policy = "ifnotpresent"
+    image = "{}:{}".format(repo, tag)
+    # should trigger a pull
+    yield spawner.pull_image(image)
+    # verify that the image exists now
+    old_image_info = yield spawner.docker("inspect_image", image)
+    print(old_image_info)
+
+    # now tag busybox:latest as our current version
+    # which is not latest!
+    yield spawner.docker("tag", image, repo)
+
+    image = repo  # implicit :latest
+    spawner.pull_policy = "ifnotpresent"
+    # check with ifnotpresent shouldn't pull
+    yield spawner.pull_image(image)
+    image_info = yield spawner.docker("inspect_image", repo)
+    assert image_info["Id"] == old_image_info["Id"]
+
+    # run again with Always,
+    # should trigger a pull even though the image is present
+    spawner.pull_policy = "always"
+    spawner.pull_image(image)
+    image_info = yield spawner.docker("inspect_image", repo)
+    assert image_info["Id"] != old_image_info["Id"]
+
+    # run again with never, make sure it's still happy
+    spawner.pull_policy = "never"
+    spawner.pull_image(image)

--- a/tests/volumes_test.py
+++ b/tests/volumes_test.py
@@ -3,12 +3,10 @@
 from __future__ import absolute_import, division, print_function
 
 import types
-import pytest
 from traitlets.config import LoggingConfigurable
 
 
 def test_binds(monkeypatch):
-    import jupyterhub
 
     monkeypatch.setattr("jupyterhub.spawner.Spawner", _MockSpawner)
     from dockerspawner.dockerspawner import DockerSpawner


### PR DESCRIPTION
default: ifnotpresent

This removes the common requirement to pull the default image.
It is pulled by default on the first launch.

closes #121