### PR TITLE
Return None on poll of "starting" container

### DIFF
--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -126,7 +126,7 @@ class SwarmSpawner(DockerSpawner):
             "Service %s status: %s", self.service_id[:7], pformat(service_state)
         )
 
-        if service_state["State"] in {"running", "pending", "preparing"}:
+        if service_state["State"] in {"running", "starting", "pending", "preparing"}:
             return None
 
         else:


### PR DESCRIPTION
[Hub docs](https://jupyterhub.readthedocs.io/en/stable/api/spawner.html#jupyterhub.spawner.Spawner.poll) say that poll should return None when the server is still starting.

DockerSpawner's poll function most likely needs to change as well, but I don't really understand how it's doing the status check, so I'm not going to touch it.