### PR TITLE
default image_whitelist to empty dict

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -191,6 +191,7 @@ class DockerSpawner(Spawner):
 
     image_whitelist = Union(
         [Any(), Dict(), List()],
+        default_value={},
         config=True,
         help="""
         List or dict of images that users can run.


### PR DESCRIPTION
this was the intended behavior

Only list, dict, and callable returning list or dict are valid

None is not a valid whitelist

closes https://github.com/jupyterhub/jupyterhub/issues/2318