### PR TITLE
fix incompatible method template_namespace

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -679,7 +679,6 @@ class DockerSpawner(Spawner):
 
     object_id = Unicode(allow_none=True)
 
-    @property
     def template_namespace(self):
         escaped_image = self.image.replace("/", "_")
         server_name = getattr(self, "name", "")
@@ -695,7 +694,7 @@ class DockerSpawner(Spawner):
     @property
     def object_name(self):
         """Render the name of our container/service using name_template"""
-        return self.name_template.format(**self.template_namespace)
+        return self.name_template.format(**self.template_namespace())
 
     def load_state(self, state):
         super(DockerSpawner, self).load_state(state)

--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -254,7 +254,7 @@ class SwarmSpawner(DockerSpawner):
             status = service["Status"]
             state = status["State"].lower()
             self.log.debug("Service %s state: %s", self.service_id[:7], state)
-            if state in {"starting", "pending", "preparing"}:
+            if state in {"new", "assigned", "accepted", "starting", "pending", "preparing"}:
                 # not ready yet, wait before checking again
                 yield gen.sleep(dt)
                 # exponential backoff

--- a/dockerspawner/volumenamingstrategy.py
+++ b/dockerspawner/volumenamingstrategy.py
@@ -1,12 +1,12 @@
 def default_format_volume_name(template, spawner):
-    return template.format(**spawner.template_namespace)
+    return template.format(**spawner.template_namespace())
 
 def escaped_format_volume_name(template, spawner):
     """Use this strategy if your usernames include illegal characters
     for volume names and you do not use absolute paths in your volume
     template.
     """
-    ns = spawner.template_namespace
+    ns = spawner.template_namespace()
     ns['username'] = spawner.escaped_name
     return template.format(**ns)
 


### PR DESCRIPTION
Fixes #290 #291 

According to the parent class [Spawner](https://github.com/jupyterhub/jupyterhub/blob/7742bfdda5f466ed8f291c49bcb774a2bfad9c1e/jupyterhub/spawner.py#L766), the method template_namespace() should be a method.
So the template_namespace() method of the subclass DockerSpawner should also be a method, instead of a property (which caused the 'dict' object is not callable' error mentioned in #290 and #291). 

So I removed the `@property` decorator.