### PR TITLE
Added post_start_cmd

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -632,12 +632,16 @@ class DockerSpawner(Spawner):
         e.g. calling 'docker exec'
         """
 
-        yield self.get_object()
+        container = yield self.get_object()
+        container_id = container[self.object_id_key]
+
         exec_kwargs = {
             'cmd': self.post_start_cmd,
-            'container': self.container_id
+            'container': container_id
         }
+        
         exec_id = yield self.docker("exec_create", **exec_kwargs)
+
         return self.docker("exec_start", exec_id=exec_id)
 
     @property


### PR DESCRIPTION
This PR adds the ability to execute additional commands inside the container after starting it.
Useful for copying a notebook from a read_only volume mount somewhere like `/tmp/notebooks/` to home directory for temporary users to interact with a notebook unique for every user instead of mounting the notebook on a read-write volume.

My motivation for doing this is that I run JupyterHub server for a temporary amount of time to conduct a seminar or presentation in my lab where I want the students experiment around with the data. So there're no users created permanently. 

The server would run a bare minimum image with the needed packages then I mount the data on a read-only volume such as `/home/temp_user/Data/*` and the notebook will be copied to `/home/temp_user/notebook.ipynb`.

Edit: Example usage:
``` python
c.DockerSpawner.read_only_volumes = {
    '/home/{host}/seminar/data': '/home/temp_user/Data/',
    '/home/{host}/seminar/notebooks': '/tmp/notebooks/'
}
c.DockerSpawner.post_start_cmd = '/bin/sh -c "cp /tmp/notebooks/* ."'
```

Thanks!