### PR TITLE
fix cpu_limit no effect bug

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -858,7 +858,8 @@ class DockerSpawner(Spawner):
 
         # build the dictionary of keyword arguments for host_config
         host_config = dict(binds=self.volume_binds, links=self.links)
-
+        self.log.debug('extra_host_config: %s', self.extra_host_config)
+        host_config.update(self.extra_host_config)
         if getattr(self, "mem_limit", None) is not None:
             # If jupyterhub version > 0.7, mem_limit is a traitlet that can
             # be directly configured. If so, use it to set mem_limit.
@@ -868,7 +869,7 @@ class DockerSpawner(Spawner):
         if not self.use_internal_ip:
             host_config["port_bindings"] = {self.port: (self.host_ip,)}
         self.log.debug('extra_host_config', self.extra_host_config)
-        host_config.update(self.extra_host_config)
+
         host_config.setdefault("network_mode", self.network_name)
 
         self.log.debug("Starting host with config: %s", host_config)

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -868,6 +868,7 @@ class DockerSpawner(Spawner):
 
         if not self.use_internal_ip:
             host_config["port_bindings"] = {self.port: (self.host_ip,)}
+        self.log.debug('extra_host_config', self.extra_host_config)
         host_config.update(self.extra_host_config)
         host_config.setdefault("network_mode", self.network_name)
 

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -866,6 +866,10 @@ class DockerSpawner(Spawner):
             # this will still be overriden by extra_host_config
             host_config["mem_limit"] = self.mem_limit
 
+        if getattr(self, "cpu_limit", None) is not None:
+            host_config["cpu_period"] = 100000
+            host_config["cpu_quota"] = 50000 * self.cpu_limit
+
         if not self.use_internal_ip:
             host_config["port_bindings"] = {self.port: (self.host_ip,)}
         self.log.debug('extra_host_config', self.extra_host_config)


### PR DESCRIPTION
In the process of using DockerSpawner, I want to limit the CPU usage of the entire container, but cpu_limit only limits the CPU usage of each ipynb, 
![image](https://user-images.githubusercontent.com/28781481/58161365-b5f0f080-7cb2-11e9-86b5-224c716b849f.png)

![image](https://user-images.githubusercontent.com/28781481/58161275-8e9a2380-7cb2-11e9-8916-5ed3ae070d00.png)

so I want to use c.dockerspawner. extra_host_config to limit that, 
```
c.DockerSpawner.extra_host_config.update({
    'cpu_period': 100000,
    'cpu_quota': 50000,
})
```
and I find that it doesn't work. So now I've made some changes

```
 $ docker inspect jupyter-kkk|grep Cpu
            "CpuShares": 0,
            "NanoCpus": 0,
            "CpuPeriod": 100000,
            "CpuQuota": 50000,
            "CpuRealtimePeriod": 0,
            "CpuRealtimeRuntime": 0,
            "CpusetCpus": "",
            "CpusetMems": "",
            "CpuCount": 0,
            "CpuPercent": 0,
```
