### PR TITLE
Make default name_template compatible with named servers.

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -306,7 +306,6 @@ class DockerSpawner(Spawner):
     )
 
     name_template = Unicode(
-        "{prefix}-{username}-{servername}",
         config=True,
         help=dedent(
             """
@@ -315,10 +314,19 @@ class DockerSpawner(Spawner):
             (may contain uppercase, special characters).
             It is important to include {servername} if JupyterHub's "named
             servers" are enabled (JupyterHub.allow_named_servers = True).
-            The default name_template is {prefix}-{username}-{servername}.
+            If the server is named, the default name_template is
+            "{prefix}-{username}-{servername}". If it is unnamed, the default
+            name_template is "{prefix}-{username}".
             """
         ),
     )
+
+    @default('name_template')
+    def _default_name_template(self):
+        if self.name:
+            return "{prefix}-{username}-{servername}"
+        else:
+            return "{prefix}-{username}"
 
     client_kwargs = Dict(
         config=True,

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -306,14 +306,16 @@ class DockerSpawner(Spawner):
     )
 
     name_template = Unicode(
-        "{prefix}-{username}",
+        "{prefix}-{username}-{servername}",
         config=True,
         help=dedent(
             """
-            Name of the container or service: with {username}, {imagename}, {prefix} replacements.
+            Name of the container or service: with {username}, {imagename}, {prefix}, {servername} replacements.
             {raw_username} can be used for the original, not escaped username
             (may contain uppercase, special characters).
-            The default name_template is <prefix>-<username> for backward compatibility.
+            It is important to include {servername} if JupyterHub's "named
+            servers" are enabled (JupyterHub.allow_named_servers = True).
+            The default name_template is {prefix}-{username}-{servername}.
             """
         ),
     )


### PR DESCRIPTION
As noted by @zeehio in [this comment](https://github.com/jupyterhub/dockerspawner/issues/257#issuecomment-492275806)
the default ``name_template`` is not compatible with using named servers. Should the default be updated?

The current docstring mentions backward compatibility. If
backward-compatibility of container names is very important, perhaps it would
be better to leave the default as is and simply mention ``{servername}`` in the
docstring and the README.