### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,22 @@
-sudo: required
 language: python
-python:
-  - 3.5
 env:
   global:
     - ASYNC_TEST_TIMEOUT=30
-  matrix:
-    - JUPYTERHUB=0.8 EXTRA_PIP='tornado<5'
-    - JUPYTERHUB=0.9
+
+# request additional services for the jobs to access
 services:
   - docker
+
 before_install:
   - docker swarm init
   - nvm install 10; nvm use 10
   - npm install -g configurable-http-proxy
   - pip install --upgrade -r dev-requirements.txt jupyterhub==${JUPYTERHUB:-0}.* ${EXTRA_PIP}
+
 install:
   - pip install -e .
   - pip freeze
+
 script:
   - pyflakes dockerspawner
   - |
@@ -41,7 +40,22 @@ script:
       pytest -vsx
     fi
 
-matrix:
+jobs:
   include:
-    - python: 3.6
+    - name: internal-ssl test
+      python: 3.6
       env: TEST=internal-ssl
+    - name: python:3.5 + jupyterhub 0.8 + tornado < 5
+      python: 3.5
+      env: JUPYTERHUB=0.8 EXTRA_PIP='tornado<5'
+    - name: python:3.6 + jupyterhub 0.8 + tornado < 5
+      python: 3.6
+      env: JUPYTERHUB=0.8 EXTRA_PIP='tornado<5'
+    - name: python:3.7 + jupyterhub 0.9
+      python: 3.7
+      env: JUPYTERHUB=0.9
+    - name: python:3.8 + jupyterhub 0.9
+      python: 3.8
+      env: JUPYTERHUB=0.9
+  fast_finish: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
     - ASYNC_TEST_TIMEOUT=30
   matrix:
-    - JUPYTERHUB=0.8 EXTRA_PIP='tornado<5'
+    - JUPYTERHUB=0.8
     - JUPYTERHUB=0.9
 services:
   - docker
@@ -14,7 +14,7 @@ before_install:
   - docker swarm init
   - nvm install 10; nvm use 10
   - npm install -g configurable-http-proxy
-  - pip install --pre --upgrade -r dev-requirements.txt jupyterhub==${JUPYTERHUB:-0}.* ${EXTRA_PIP}
+  - pip install --pre --upgrade -r dev-requirements.txt jupyterhub==${JUPYTERHUB:-0}.*
 install:
   - pip install -e .
   - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
     - ASYNC_TEST_TIMEOUT=30
   matrix:
-    - JUPYTERHUB=0.8
+    - JUPYTERHUB=0.8 EXTRA_PIP='tornado<5'
     - JUPYTERHUB=0.9
 services:
   - docker
@@ -14,7 +14,7 @@ before_install:
   - docker swarm init
   - nvm install 10; nvm use 10
   - npm install -g configurable-http-proxy
-  - pip install --pre --upgrade -r dev-requirements.txt jupyterhub==${JUPYTERHUB:-0}.*
+  - pip install --upgrade -r dev-requirements.txt jupyterhub==${JUPYTERHUB:-0}.* ${EXTRA_PIP}
 install:
   - pip install -e .
   - pip freeze

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 codecov
-pytest>=3.6,<4
+pytest>=3.6
 pytest-cov
 pytest-tornado
 pyflakes


### PR DESCRIPTION
- since `pytest-cov:2.10.0`, [pytest>=4.6 is required](https://github.com/pytest-dev/pytest-cov/blob/master/CHANGELOG.rst#2100-2020-06-12)
- `notebook>=6.1.*` errors if [Tornado < 5](https://github.com/jupyter/notebook/blob/e937fd79927e5806656a4229091d9814686626d2/docs/source/changelog.rst#610) (at the moment there is only a beta release for `notebook:6.1.0`, but once a stable version is release, the tests will fail again)
- the CI jobs were a bit re-organized

This is only a temporary fix, because a new release of the `notebook` will break the tests again.
I think a more permanent solution would be to test instead with the latest two JupyterHub versions (1.0 and 1.1.0). This means we should:
- switch from `pytest-tornado` to `pytest-asyncio`
- have a working jupyterhub/singleuser version for JupyterHub 1.1.0 (ref: https://github.com/jupyterhub/jupyterhub/issues/2911)

Update: Just realized that pinning pytest-cov to 2.9.0 would have probably been a easier fix :sweat_smile: 