### PR TITLE
Add release instructions and Travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,9 @@ script:
     fi
 
 jobs:
+  fast_finish: true
   include:
+    # Default stage: test
     - name: internal-ssl test
       python: 3.6
       env: TEST=internal-ssl
@@ -57,5 +59,16 @@ jobs:
     - name: python:3.8 + jupyterhub 0.9
       python: 3.8
       env: JUPYTERHUB=0.9
-  fast_finish: true
-
+    # Only deploy if all test jobs passed
+    - stage: deploy
+      python: 3.7
+      if: tag IS present
+      deploy:
+        provider: pypi
+        user: __token__
+        # password: see secret PYPI_PASSWORD variable
+        distributions: sdist bdist_wheel
+        on:
+          # Without this we get the note about:
+          # Skipping a deployment with the pypi provider because this branch is not permitted: <tag>
+          tags: true

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,76 @@
+# How to make a release
+
+`dockerspawner` is a package [available on
+PyPI](https://pypi.org/project/dockerspawner/).
+The PyPI release is done automatically by TravisCI when a tag
+is pushed.
+
+For you to follow along according to these instructions, you need
+to have push rights to the [dockerspawner GitHub
+repository](https://github.com/jupyterhub/dockerspawner).
+
+## Steps to make a release
+
+1. Checkout master and make sure it is up to date.
+
+   ```bash
+   ORIGIN=${ORIGIN:-origin} # set to the canonical remote, e.g. 'upstream' if 'origin' is not the official repo
+   git checkout master
+   git fetch $ORIGIN master
+   git reset --hard $ORIGIN/master
+   # WARNING! This next command deletes any untracked files in the repo
+   git clean -xfd
+   ```
+
+1. Update [CHANGELOG.md](CHANGELOG.md) and add it to
+   the working tree.
+   
+   ```bash
+   git add CHANGELOG.md
+   ```
+
+   Tip: Identifying the changes can be made easier with the help of the
+   [choldgraf/github-activity](https://github.com/choldgraf/github-activity)
+   utility.
+
+1. Set the `version_info` variable in [\_version.py](dockerspawner/_version.py)
+   appropriately and make a commit.
+
+   ```bash
+   git add dockerspawner/_version.py
+   VERSION=...  # e.g. 1.2.3
+   git commit -m "release $VERSION"
+   ```
+
+   Tip: You can get the current project version by checking the [latest
+   tag on GitHub](https://github.com/jupyterhub/dockerspawner/tags).
+
+
+1. Reset the `version_info` variable in
+   [\_version.py](dockerspawner/_version.py) appropriately with an incremented
+   patch version and a `dev` element, then make a commit.
+   ```bash
+   git add dockerspawner/_version.py
+   git commit -m "back to dev"
+   ```
+
+1. Push your two commits to master.
+
+   ```bash
+   # first push commits without a tags to ensure the
+   # commits comes through, because a tag can otherwise
+   # be pushed all alone without company of rejected
+   # commits, and we want have our tagged release coupled
+   # with a specific commit in master
+   git push $ORIGIN master
+   ```
+
+1. Create a git tag for the pushed release commit and push it.
+
+   ```bash
+   git tag -a $VERSION -m "release $VERSION"
+   # then verify you tagged the right commit
+   git log
+   # then push it
+   git push $ORIGIN --follow-tags
+   ```

--- a/dockerspawner/_version.py
+++ b/dockerspawner/_version.py
@@ -1,1 +1,15 @@
-__version__ = '0.12.0.dev'
+"""dockerspawner version info"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+version_info = (
+    0,
+    12,
+    0,
+    'dev',  # comment-out this line for a release
+)
+__version__ = '.'.join(map(str, version_info[:3]))
+
+if len(version_info) > 3:
+    __version__ = '%s%s' % (__version__, version_info[3])


### PR DESCRIPTION
Adds release instructions and a travis deploy job.

@consideRatio, do you think you can help with the `PYPI_PASSWORD` env var setup here too? :heart: 