### PR TITLE
Test with latest jh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,12 @@ jobs:
     - name: python:3.6 + jupyterhub 1.0
       python: 3.6
       env: JUPYTERHUB=1.0
-    - name: python:3.7 + jupyterhub 1.2.0dev
+    - name: python:3.7 + jupyterhub 1.1.0
       python: 3.7
-      env: JUPYTERHUB=1.2.0dev
-    - name: python:3.8 + jupyterhub 1.2.0dev
+      env: JUPYTERHUB=1.1.0
+    - name: python:3.8 + jupyterhub 1.1.0
       python: 3.8
-      env: JUPYTERHUB=1.2.0dev
+      env: JUPYTERHUB=1.1.0
 
     # Only deploy if all test jobs passed
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - docker swarm init
   - nvm install 10; nvm use 10
   - npm install -g configurable-http-proxy
-  - pip install --upgrade -r dev-requirements.txt jupyterhub==${JUPYTERHUB:-0}.* ${EXTRA_PIP}
+  - pip install --upgrade -r dev-requirements.txt jupyterhub==${JUPYTERHUB:-0}.*
 
 install:
   - pip install -e .
@@ -21,7 +21,7 @@ script:
   - pyflakes dockerspawner
   - |
     # pre-pull images to avoid long wait times in tests
-    for v in 0.8 0.9; do
+    for v in 1.0 1.2.0dev; do
       docker pull jupyterhub/singleuser:$v
       # preserve the layers with a different tag
       docker tag jupyterhub/singleuser:$v jupyterhub/singleuser:${v}-cache
@@ -47,18 +47,19 @@ jobs:
     - name: internal-ssl test
       python: 3.6
       env: TEST=internal-ssl
-    - name: python:3.5 + jupyterhub 0.8 + tornado < 5
+    - name: python:3.5 + jupyterhub 1.0
       python: 3.5
-      env: JUPYTERHUB=0.8 EXTRA_PIP='tornado<5'
-    - name: python:3.6 + jupyterhub 0.8 + tornado < 5
+      env: JUPYTERHUB=1.0
+    - name: python:3.6 + jupyterhub 1.0
       python: 3.6
-      env: JUPYTERHUB=0.8 EXTRA_PIP='tornado<5'
-    - name: python:3.7 + jupyterhub 0.9
+      env: JUPYTERHUB=1.0
+    - name: python:3.7 + jupyterhub 1.2.0dev
       python: 3.7
-      env: JUPYTERHUB=0.9
-    - name: python:3.8 + jupyterhub 0.9
+      env: JUPYTERHUB=1.2.0dev
+    - name: python:3.8 + jupyterhub 1.2.0dev
       python: 3.8
-      env: JUPYTERHUB=0.9
+      env: JUPYTERHUB=1.2.0dev
+
     # Only deploy if all test jobs passed
     - stage: deploy
       python: 3.7
@@ -72,3 +73,4 @@ jobs:
           # Without this we get the note about:
           # Skipping a deployment with the pypi provider because this branch is not permitted: <tag>
           tags: true
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - pyflakes dockerspawner
   - |
     # pre-pull images to avoid long wait times in tests
-    for v in 1.0 1.2.0dev; do
+    for v in 1.0 1.1; do
       docker pull jupyterhub/singleuser:$v
       # preserve the layers with a different tag
       docker tag jupyterhub/singleuser:$v jupyterhub/singleuser:${v}-cache

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 codecov
 pytest>=3.6
 pytest-cov
-pytest-tornado
+pytest-asyncio
 pyflakes
 notebook

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,20 +9,41 @@ import pytest
 from jupyterhub.tests.mocking import MockHub
 
 # import base jupyterhub fixtures
-from jupyterhub.tests.conftest import app, io_loop  # noqa
-from dockerspawner import DockerSpawner
+from jupyterhub.tests.conftest import app, io_loop, event_loop, ssl_tmpdir  # noqa
+from dockerspawner import DockerSpawner, SwarmSpawner, SystemUserSpawner
 
 # make Hub connectable from docker by default
 MockHub.hub_ip = "0.0.0.0"
 
 
 @pytest.fixture
-def dockerspawner(app):
+def dockerspawner_configured_app(app):
     """Configure JupyterHub to use DockerSpawner"""
     app.config.DockerSpawner.prefix = "dockerspawner-test"
     # app.config.DockerSpawner.remove = True
     with mock.patch.dict(app.tornado_settings, {"spawner_class": DockerSpawner}):
-        yield
+        yield app
+
+@pytest.fixture
+def swarmspawner_configured_app(app):
+    """Configure JupyterHub to use DockerSpawner"""
+    app.config.SwarmSpawner.prefix = "dockerspawner-test"
+    with mock.patch.dict(
+        app.tornado_settings, {"spawner_class": SwarmSpawner}
+    ), mock.patch.dict(
+        app.config.SwarmSpawner, {"network_name": "bridge"}
+    ):
+        yield app
+
+
+@pytest.fixture
+def systemuserspawner_configured_app(app):
+    """Configure JupyterHub to use DockerSpawner"""
+    app.config.SwarmSpawner.prefix = "dockerspawner-test"
+    with mock.patch.dict(
+        app.tornado_settings, {"spawner_class": SystemUserSpawner}
+    ):
+        yield app
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -29,6 +29,7 @@ async def test_start_stop(dockerspawner_configured_app):
         r = await api_request(app, "users", name, "server", method="post")
     assert r.status_code == 201, r.text
 
+    url = url_path_join(public_url(app, user), "api/status")
     resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
     assert resp.effective_url == url
     resp.rethrow()
@@ -60,6 +61,8 @@ async def test_allowed_image(dockerspawner_configured_app, image):
         # request again
         r = await api_request(app, "users", name, "server", method="post")
     assert r.status_code == 201, r.text
+
+    url = url_path_join(public_url(app, user), "api/status")
     resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
     assert resp.effective_url == url
     resp.rethrow()

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -2,56 +2,54 @@
 
 import json
 
+import asyncio
 import docker
 import pytest
 from jupyterhub.tests.test_api import add_user, api_request
 from jupyterhub.tests.mocking import public_url
-from jupyterhub.tests.utils import async_requests
 from jupyterhub.utils import url_path_join
-from tornado import gen
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 from dockerspawner import DockerSpawner
 
-pytestmark = pytest.mark.usefixtures("dockerspawner")
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
 
-
-@pytest.mark.gen_test(timeout=90)
-def test_start_stop(app):
+async def test_start_stop(dockerspawner_configured_app):
+    app = dockerspawner_configured_app
     name = "has@"
     add_user(app.db, app, name=name)
     user = app.users[name]
     assert isinstance(user.spawner, DockerSpawner)
     token = user.new_api_token()
     # start the server
-    r = yield api_request(app, "users", name, "server", method="post")
+    r = await api_request(app, "users", name, "server", method="post")
     while r.status_code == 202:
         # request again
-        r = yield api_request(app, "users", name, "server", method="post")
-        yield gen.sleep(0.1)
+        r = await api_request(app, "users", name, "server", method="post")
     assert r.status_code == 201, r.text
-    url = url_path_join(public_url(app, user), "api/status")
-    r = yield async_requests.get(url, headers={"Authorization": "token %s" % token})
-    assert r.url == url
-    r.raise_for_status()
-    print(r.text)
-    assert "kernels" in r.json()
+
+    resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
+    assert resp.effective_url == url
+    resp.rethrow()
+    assert "kernels" in resp.body.decode("utf-8")
 
 
-@pytest.mark.gen_test(timeout=90)
-@pytest.mark.parametrize("image", ["0.8", "0.9", "nomatch"])
-def test_allowed_image(app, image):
+@pytest.mark.parametrize("image", ["1.0", "1.2.0dev", "nomatch"])
+def test_allowed_image(dockerspawner_configured_app, image):
+    app = dockerspawner_configured_app
     name = "checker"
     add_user(app.db, app, name=name)
     user = app.users[name]
     assert isinstance(user.spawner, DockerSpawner)
     user.spawner.remove_containers = True
-    user.spawner.allowed_images = {
-        "0.9": "jupyterhub/singleuser:0.9",
-        "0.8": "jupyterhub/singleuser:0.8",
+    user.spawner.image_whitelist = {
+        "1.0": "jupyterhub/singleuser:1.0",
+        "1.2": "jupyterhub/singleuser:1.2.0dev",
     }
     token = user.new_api_token()
     # start the server
-    r = yield api_request(
+    r = await api_request(
         app, "users", name, "server", method="post", data=json.dumps({"image": image})
     )
     if image not in user.spawner.allowed_images:
@@ -60,21 +58,21 @@ def test_allowed_image(app, image):
         return
     while r.status_code == 202:
         # request again
-        r = yield api_request(app, "users", name, "server", method="post")
-        yield gen.sleep(0.1)
+        r = await api_request(app, "users", name, "server", method="post")
     assert r.status_code == 201, r.text
-    url = url_path_join(public_url(app, user), "api/status")
-    r = yield async_requests.get(url, headers={"Authorization": "token %s" % token})
-    r.raise_for_status()
-    assert r.headers['x-jupyterhub-version'].startswith(image)
-    r = yield api_request(
+    resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
+    assert resp.effective_url == url
+    resp.rethrow()
+
+    assert resp.headers['x-jupyterhub-version'].startswith(image)
+    r = await api_request(
         app, "users", name, "server", method="delete",
     )
     r.raise_for_status()
 
 
-@pytest.mark.gen_test(timeout=90)
-def test_image_pull_policy(app):
+def test_image_pull_policy(dockerspawner_configured_app):
+    app = dockerspawner_configured_app
     name = "gumby"
     add_user(app.db, app, name=name)
     user = app.users[name]
@@ -83,40 +81,40 @@ def test_image_pull_policy(app):
     spawner.image = "jupyterhub/doesntexist:nosuchtag"
     with pytest.raises(docker.errors.NotFound):
         spawner.image_pull_policy = "never"
-        yield spawner.pull_image(spawner.image)
+        await spawner.pull_image(spawner.image)
 
     repo = "busybox"
     tag = "1.29.1"  # a version that's definitely not latest
     # ensure image isn't present
     try:
-        yield spawner.docker("remove_image", "{}:{}".format(repo, tag))
+        await asyncio.wrap_future(spawner.docker("remove_image", "{}:{}".format(repo, tag)))
     except docker.errors.ImageNotFound:
         pass
 
     spawner.pull_policy = "ifnotpresent"
     image = "{}:{}".format(repo, tag)
     # should trigger a pull
-    yield spawner.pull_image(image)
+    await spawner.pull_image(image)
     # verify that the image exists now
-    old_image_info = yield spawner.docker("inspect_image", image)
+    old_image_info = await asyncio.wrap_future(spawner.docker("inspect_image", image))
     print(old_image_info)
 
     # now tag busybox:latest as our current version
     # which is not latest!
-    yield spawner.docker("tag", image, repo)
+    await asyncio.wrap_future(spawner.docker("tag", image, repo))
 
     image = repo  # implicit :latest
     spawner.pull_policy = "ifnotpresent"
     # check with ifnotpresent shouldn't pull
-    yield spawner.pull_image(image)
-    image_info = yield spawner.docker("inspect_image", repo)
+    await spawner.pull_image(image)
+    image_info = await asyncio.wrap_future(spawner.docker("inspect_image", repo))
     assert image_info["Id"] == old_image_info["Id"]
 
     # run again with Always,
     # should trigger a pull even though the image is present
     spawner.pull_policy = "always"
     spawner.pull_image(image)
-    image_info = yield spawner.docker("inspect_image", repo)
+    image_info = await asyncio.wrap_future(spawner.docker("inspect_image", repo))
     assert image_info["Id"] != old_image_info["Id"]
 
     # run again with never, make sure it's still happy

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -36,7 +36,7 @@ async def test_start_stop(dockerspawner_configured_app):
 
 
 @pytest.mark.parametrize("image", ["1.0", "1.2.0dev", "nomatch"])
-def test_allowed_image(dockerspawner_configured_app, image):
+async def test_allowed_image(dockerspawner_configured_app, image):
     app = dockerspawner_configured_app
     name = "checker"
     add_user(app.db, app, name=name)
@@ -71,7 +71,7 @@ def test_allowed_image(dockerspawner_configured_app, image):
     r.raise_for_status()
 
 
-def test_image_pull_policy(dockerspawner_configured_app):
+async def test_image_pull_policy(dockerspawner_configured_app):
     app = dockerspawner_configured_app
     name = "gumby"
     add_user(app.db, app, name=name)

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -36,7 +36,7 @@ async def test_start_stop(dockerspawner_configured_app):
     assert "kernels" in resp.body.decode("utf-8")
 
 
-@pytest.mark.parametrize("image", ["1.0", "1.2.0dev", "nomatch"])
+@pytest.mark.parametrize("image", ["1.0", "1.1.0", "nomatch"])
 async def test_allowed_image(dockerspawner_configured_app, image):
     app = dockerspawner_configured_app
     name = "checker"
@@ -44,9 +44,9 @@ async def test_allowed_image(dockerspawner_configured_app, image):
     user = app.users[name]
     assert isinstance(user.spawner, DockerSpawner)
     user.spawner.remove_containers = True
-    user.spawner.image_whitelist = {
+    user.spawner.allowed_images = {
         "1.0": "jupyterhub/singleuser:1.0",
-        "1.2": "jupyterhub/singleuser:1.2.0dev",
+        "1.1": "jupyterhub/singleuser:1.1",
     }
     token = user.new_api_token()
     # start the server

--- a/tests/test_swarmspawner.py
+++ b/tests/test_swarmspawner.py
@@ -13,8 +13,7 @@ from dockerspawner import SwarmSpawner
 # Mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
 
-@pytest.mark.gen_test
-def test_start_stop(swarmspawner_configured_app):
+async def test_start_stop(swarmspawner_configured_app):
     app = swarmspawner_configured_app
     name = "somebody"
     add_user(app.db, app, name=name)

--- a/tests/test_swarmspawner.py
+++ b/tests/test_swarmspawner.py
@@ -27,6 +27,7 @@ async def test_start_stop(swarmspawner_configured_app):
         r = await api_request(app, "users", name, "server", method="post")
     assert r.status_code == 201, r.text
 
+    url = url_path_join(public_url(app, user), "api/status")
     resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
     assert resp.effective_url == url
     resp.rethrow()

--- a/tests/test_swarmspawner.py
+++ b/tests/test_swarmspawner.py
@@ -5,42 +5,30 @@ from unittest import mock
 import pytest
 from jupyterhub.tests.test_api import add_user, api_request
 from jupyterhub.tests.mocking import public_url
-from jupyterhub.tests.utils import async_requests
 from jupyterhub.utils import url_path_join
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 from dockerspawner import SwarmSpawner
 
-pytestmark = pytest.mark.usefixtures("swarmspawner")
-
-
-@pytest.fixture
-def swarmspawner(app):
-    """Configure JupyterHub to use DockerSpawner"""
-    app.config.SwarmSpawner.prefix = "dockerspawner-test"
-    with mock.patch.dict(
-        app.tornado_settings, {"spawner_class": SwarmSpawner}
-    ), mock.patch.dict(
-        app.config.SwarmSpawner, {"network_name": "bridge"}
-    ):
-        yield
-
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
 
 @pytest.mark.gen_test
-def test_start_stop(app):
+def test_start_stop(swarmspawner_configured_app):
+    app = swarmspawner_configured_app
     name = "somebody"
     add_user(app.db, app, name=name)
     user = app.users[name]
     assert isinstance(user.spawner, SwarmSpawner)
     token = user.new_api_token()
     # start the server
-    r = yield api_request(app, "users", name, "server", method="post")
+    r = await api_request(app, "users", name, "server", method="post")
     while r.status_code == 202:
         # request again
-        r = yield api_request(app, "users", name, "server", method="post")
+        r = await api_request(app, "users", name, "server", method="post")
     assert r.status_code == 201, r.text
-    url = url_path_join(public_url(app, user), "api/status")
-    r = yield async_requests.get(url, headers={"Authorization": "token %s" % token})
-    assert r.url == url
-    r.raise_for_status()
-    print(r.text)
-    assert "kernels" in r.json()
+
+    resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
+    assert resp.effective_url == url
+    resp.rethrow()
+    assert "kernels" in resp.body.decode("utf-8")

--- a/tests/test_systemuserspawner.py
+++ b/tests/test_systemuserspawner.py
@@ -7,15 +7,14 @@ import pytest
 from jupyterhub.tests.test_api import add_user, api_request
 from jupyterhub.tests.mocking import public_url
 from jupyterhub.utils import url_path_join
- from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 from dockerspawner import SystemUserSpawner
 
 # Mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
 
-@pytest.mark.gen_test
-def test_start_stop(systemuserspawner_configured_app):
+async def test_start_stop(systemuserspawner_configured_app):
     app = systemuserspawner_configured_app
     name = getuser()
     add_user(app.db, app, name=name)

--- a/tests/test_systemuserspawner.py
+++ b/tests/test_systemuserspawner.py
@@ -28,6 +28,7 @@ async def test_start_stop(systemuserspawner_configured_app):
         r = await api_request(app, "users", name, "server", method="post")
     assert r.status_code == 201, r.text
     
+    url = url_path_join(public_url(app, user), "api/status")
     resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
     assert resp.effective_url == url
     resp.rethrow()

--- a/tests/test_systemuserspawner.py
+++ b/tests/test_systemuserspawner.py
@@ -6,40 +6,30 @@ from unittest import mock
 import pytest
 from jupyterhub.tests.test_api import add_user, api_request
 from jupyterhub.tests.mocking import public_url
-from jupyterhub.tests.utils import async_requests
 from jupyterhub.utils import url_path_join
+ from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 from dockerspawner import SystemUserSpawner
 
-pytestmark = pytest.mark.usefixtures("systemuserspawner")
-
-
-@pytest.fixture
-def systemuserspawner(app):
-    """Configure JupyterHub to use DockerSpawner"""
-    app.config.SwarmSpawner.prefix = "dockerspawner-test"
-    with mock.patch.dict(
-        app.tornado_settings, {"spawner_class": SystemUserSpawner}
-    ):
-        yield
-
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
 
 @pytest.mark.gen_test
-def test_start_stop(app):
+def test_start_stop(systemuserspawner_configured_app):
+    app = systemuserspawner_configured_app
     name = getuser()
     add_user(app.db, app, name=name)
     user = app.users[name]
     assert isinstance(user.spawner, SystemUserSpawner)
     token = user.new_api_token()
     # start the server
-    r = yield api_request(app, "users", name, "server", method="post")
+    r = await api_request(app, "users", name, "server", method="post")
     while r.status_code == 202:
         # request again
-        r = yield api_request(app, "users", name, "server", method="post")
+        r = await api_request(app, "users", name, "server", method="post")
     assert r.status_code == 201, r.text
-    url = url_path_join(public_url(app, user), "api/status")
-    r = yield async_requests.get(url, headers={"Authorization": "token %s" % token})
-    assert r.url == url
-    r.raise_for_status()
-    print(r.text)
-    assert "kernels" in r.json()
+    
+    resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
+    assert resp.effective_url == url
+    resp.rethrow()
+    assert "kernels" in resp.body.decode("utf-8")


### PR DESCRIPTION
- Updates the tests to work with latest JupyterHub versions: 1.0 and 1.1
- Use `pytest-asyncio` instead of `pytest-tornado`.

Note: `jupyterhub/singleuser:1.1` doesn't exist due to an issue with docker tags so the tests for JH 1.1 fail.