### PR TITLE
avoid name collisions when using named servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - docker swarm init
   - nvm install 10; nvm use 10
   - npm install -g configurable-http-proxy
+  - pip install --upgrade setuptools pip
   - pip install --upgrade -r dev-requirements.txt jupyterhub==${JUPYTERHUB:-0}.*
 
 install:

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -326,7 +326,7 @@ class DockerSpawner(Spawner):
             It is important to include {servername} if JupyterHub's "named
             servers" are enabled (JupyterHub.allow_named_servers = True).
             If the server is named, the default name_template is
-            "{prefix}-{username}.{servername}". If it is unnamed, the default
+            "{prefix}-{username}__{servername}". If it is unnamed, the default
             name_template is "{prefix}-{username}".
 
             Note: when using named servers,
@@ -340,7 +340,7 @@ class DockerSpawner(Spawner):
     @default('name_template')
     def _default_name_template(self):
         if self.name:
-            return "{prefix}-{username}.{servername}"
+            return "{prefix}-{username}__{servername}"
         else:
             return "{prefix}-{username}"
 
@@ -840,7 +840,7 @@ class DockerSpawner(Spawner):
 
     @gen.coroutine
     def get_object(self):
-        self.log.debug("Getting container '%s'", self.object_name)
+        self.log.debug("Getting %s '%s'", self.object_type, self.object_name)
         try:
             obj = yield self.docker("inspect_%s" % self.object_type, self.object_name)
             self.object_id = obj[self.object_id_key]

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -750,10 +750,17 @@ class DockerSpawner(Spawner):
         else:
             self.object_id = state.get("object_id", "")
 
+        # override object_name from state if defined
+        # to avoid losing track of running servers
+        self.object_name = state.get("object_name", None) or self.object_name
+
     def get_state(self):
         state = super(DockerSpawner, self).get_state()
         if self.object_id:
             state["object_id"] = self.object_id
+            # persist object_name if running
+            # so that a change in the template doesn't lose track of running servers
+            state["object_name"] = self.object_name
         return state
 
     def _public_hub_api_url(self):

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -326,8 +326,13 @@ class DockerSpawner(Spawner):
             It is important to include {servername} if JupyterHub's "named
             servers" are enabled (JupyterHub.allow_named_servers = True).
             If the server is named, the default name_template is
-            "{prefix}-{username}-{servername}". If it is unnamed, the default
+            "{prefix}-{username}.{servername}". If it is unnamed, the default
             name_template is "{prefix}-{username}".
+
+            Note: when using named servers,
+            it is important that the separator between {username} and {servername}
+            is not a character that can occur in an escaped {username},
+            and also not the single escape character '_'.
             """
         ),
     )
@@ -335,7 +340,7 @@ class DockerSpawner(Spawner):
     @default('name_template')
     def _default_name_template(self):
         if self.name:
-            return "{prefix}-{username}-{servername}"
+            return "{prefix}-{username}.{servername}"
         else:
             return "{prefix}-{username}"
 
@@ -728,17 +733,20 @@ class DockerSpawner(Spawner):
     def template_namespace(self):
         escaped_image = self.image.replace("/", "_")
         server_name = getattr(self, "name", "")
+        safe_server_name = self._escape(server_name.lower())
         return {
             "username": self.escaped_name,
-            "safe_username": self.user.name,
+            "safe_username": self.escaped_name,
             "raw_username": self.user.name,
             "imagename": escaped_image,
-            "servername": server_name,
+            "servername": safe_server_name,
+            "raw_servername": server_name,
             "prefix": self.prefix,
         }
 
-    @property
-    def object_name(self):
+    object_name = Unicode()
+    @default("object_name")
+    def _object_name_default(self):
         """Render the name of our container/service using name_template"""
         return self.name_template.format(**self.template_namespace())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,15 +17,25 @@ MockHub.hub_ip = "0.0.0.0"
 
 
 @pytest.fixture
-def dockerspawner_configured_app(app):
+def named_servers(app):
+    with mock.patch.dict(
+        app.tornado_settings,
+        {"allow_named_servers": True, "named_server_limit_per_user": 2},
+    ):
+        yield
+
+
+@pytest.fixture
+def dockerspawner_configured_app(app, named_servers):
     """Configure JupyterHub to use DockerSpawner"""
     app.config.DockerSpawner.prefix = "dockerspawner-test"
     # app.config.DockerSpawner.remove = True
     with mock.patch.dict(app.tornado_settings, {"spawner_class": DockerSpawner}):
         yield app
 
+
 @pytest.fixture
-def swarmspawner_configured_app(app):
+def swarmspawner_configured_app(app, named_servers):
     """Configure JupyterHub to use DockerSpawner"""
     app.config.SwarmSpawner.prefix = "dockerspawner-test"
     with mock.patch.dict(
@@ -37,9 +47,9 @@ def swarmspawner_configured_app(app):
 
 
 @pytest.fixture
-def systemuserspawner_configured_app(app):
+def systemuserspawner_configured_app(app, named_servers):
     """Configure JupyterHub to use DockerSpawner"""
-    app.config.SwarmSpawner.prefix = "dockerspawner-test"
+    app.config.DockerSpawner.prefix = "dockerspawner-test"
     with mock.patch.dict(
         app.tornado_settings, {"spawner_class": SystemUserSpawner}
     ):

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -1,35 +1,53 @@
 """Tests for DockerSpawner class"""
 
+import asyncio
 import json
 
-import asyncio
 import docker
 import pytest
 from jupyterhub.tests.test_api import add_user, api_request
 from jupyterhub.tests.mocking import public_url
 from jupyterhub.utils import url_path_join
-from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+from tornado.httpclient import AsyncHTTPClient
 
 from dockerspawner import DockerSpawner
 
 # Mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
 
+def test_name_collision(dockerspawner_configured_app):
+    app = dockerspawner_configured_app
+    has_hyphen = "user--foo"
+    add_user(app.db, app, name=has_hyphen)
+    user = app.users[has_hyphen]
+    spawner1 = user.spawners[""]
+    assert isinstance(spawner1, DockerSpawner)
+    assert spawner1.object_name == "{}-{}".format(spawner1.prefix, has_hyphen)
+
+    part1, part2 = ["user", "foo"]
+    add_user(app.db, app, name=part1)
+    user2 = app.users[part1]
+    spawner2 = user2.spawners[part2]
+    assert spawner1.object_name != spawner2.object_name
+
+
 async def test_start_stop(dockerspawner_configured_app):
     app = dockerspawner_configured_app
     name = "has@"
     add_user(app.db, app, name=name)
     user = app.users[name]
-    assert isinstance(user.spawner, DockerSpawner)
+    server_name = 'also-has@'
+    spawner = user.spawners[server_name]
+    assert isinstance(spawner, DockerSpawner)
     token = user.new_api_token()
     # start the server
-    r = await api_request(app, "users", name, "server", method="post")
+    r = await api_request(app, "users", name, "servers", server_name, method="post")
     while r.status_code == 202:
         # request again
-        r = await api_request(app, "users", name, "server", method="post")
+        r = await api_request(app, "users", name, "servers", server_name, method="post")
     assert r.status_code == 201, r.text
 
-    url = url_path_join(public_url(app, user), "api/status")
+    url = url_path_join(public_url(app, user), server_name, "api/status")
     resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
     assert resp.effective_url == url
     resp.rethrow()

--- a/tests/test_swarmspawner.py
+++ b/tests/test_swarmspawner.py
@@ -23,10 +23,13 @@ async def test_start_stop(swarmspawner_configured_app):
     token = user.new_api_token()
     # start the server
     r = await api_request(app, "users", name, "servers", server_name, method="post")
-    while r.status_code == 202:
+    pending = r.status_code == 202
+    while pending:
         # request again
-        r = await api_request(app, "users", name, "servers", server_name, method="post")
-    assert r.status_code == 201, r.text
+        r = await api_request(app, "users", name)
+        user_info = r.json()
+        pending = user_info["servers"][server_name]["pending"]
+    assert r.status_code in {201, 200}, r.text
 
     url = url_path_join(public_url(app, user), server_name, "api/status")
     resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})

--- a/tests/test_swarmspawner.py
+++ b/tests/test_swarmspawner.py
@@ -1,33 +1,34 @@
 """Tests for SwarmSpawner"""
 
-from unittest import mock
-
 import pytest
 from jupyterhub.tests.test_api import add_user, api_request
 from jupyterhub.tests.mocking import public_url
 from jupyterhub.utils import url_path_join
-from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+from tornado.httpclient import AsyncHTTPClient
 
 from dockerspawner import SwarmSpawner
 
 # Mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
 
+
 async def test_start_stop(swarmspawner_configured_app):
     app = swarmspawner_configured_app
     name = "somebody"
     add_user(app.db, app, name=name)
     user = app.users[name]
-    assert isinstance(user.spawner, SwarmSpawner)
+    server_name = 'also-has@'
+    spawner = user.spawners[server_name]
+    assert isinstance(spawner, SwarmSpawner)
     token = user.new_api_token()
     # start the server
-    r = await api_request(app, "users", name, "server", method="post")
+    r = await api_request(app, "users", name, "servers", server_name, method="post")
     while r.status_code == 202:
         # request again
-        r = await api_request(app, "users", name, "server", method="post")
+        r = await api_request(app, "users", name, "servers", server_name, method="post")
     assert r.status_code == 201, r.text
 
-    url = url_path_join(public_url(app, user), "api/status")
+    url = url_path_join(public_url(app, user), server_name, "api/status")
     resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
     assert resp.effective_url == url
     resp.rethrow()

--- a/tests/test_systemuserspawner.py
+++ b/tests/test_systemuserspawner.py
@@ -1,13 +1,12 @@
 """Tests for SwarmSpawner"""
 
 from getpass import getuser
-from unittest import mock
 
 import pytest
 from jupyterhub.tests.test_api import add_user, api_request
 from jupyterhub.tests.mocking import public_url
 from jupyterhub.utils import url_path_join
-from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+from tornado.httpclient import AsyncHTTPClient
 
 from dockerspawner import SystemUserSpawner
 

--- a/tests/test_systemuserspawner.py
+++ b/tests/test_systemuserspawner.py
@@ -26,7 +26,7 @@ async def test_start_stop(systemuserspawner_configured_app):
         # request again
         r = await api_request(app, "users", name, "server", method="post")
     assert r.status_code == 201, r.text
-    
+
     url = url_path_join(public_url(app, user), "api/status")
     resp = await AsyncHTTPClient().fetch(url, headers={"Authorization": "token %s" % token})
     assert resp.effective_url == url


### PR DESCRIPTION
we haven't made a release yet with #315 (merged last month), but the default template added there allows collisions between certain usernames and named servers because `-` is considered a safe character and not escaped.

This changes the default template to use `__`, the doubled escape character (same as on KubeSpawner, which uses `-` as the escape character), which cannot occur in an escaped username or servername.

This also ensures the escaped form of servername is used in the template, matching handling of usernames.

Additionally, this persists object_name in state, to avoid changes in the template (as is done here) from causing a disconnect between objects across configuration changes.
That is, changes in the template will only affect newly created objects, not ones that already exist.

/cc @danielballan