### PR TITLE
Add a ready state to the Swarm service status

### DIFF
--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -133,7 +133,7 @@ class SwarmSpawner(DockerSpawner):
             "Service %s status: %s", self.service_id[:7], pformat(service_state)
         )
 
-        if service_state["State"] in {"running", "starting", "pending", "preparing"}:
+        if service_state["State"] in {"running", "starting", "pending", "preparing", "ready"}:
             return None
 
         else:
@@ -254,7 +254,7 @@ class SwarmSpawner(DockerSpawner):
             status = service["Status"]
             state = status["State"].lower()
             self.log.debug("Service %s state: %s", self.service_id[:7], state)
-            if state in {"new", "assigned", "accepted", "starting", "pending", "preparing"}:
+            if state in {"new", "assigned", "accepted", "starting", "pending", "preparing", "ready"}:
                 # not ready yet, wait before checking again
                 yield gen.sleep(dt)
                 # exponential backoff


### PR DESCRIPTION
Fix #372 - The state of the Swarm service could be "ready".

`READY` state does not appear in the document of Docker Swarm https://docs.docker.com/engine/swarm/how-swarm-mode-works/swarm-task-states/ but the issue docker/docker.github.io#7317 indicates actually `READY` state exists...), so an unexpected error may occur even if the container is successfully launched.