### PR TITLE
Add GitHub Action readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DockerSpawner
 
-[![TravisCI (.org) build status](https://img.shields.io/travis/com/jupyterhub/dockerspawner?logo=travis)](https://travis-ci.com/jupyterhub/dockerspawner)
+[![GitHub Workflow Status - Test](https://img.shields.io/github/workflow/status/jupyterhub/dockerspawner/Tests?logo=github&label=tests)](https://github.com/jupyterhub/dockerspawner/actions)
 [![Latest PyPI version](https://img.shields.io/pypi/v/dockerspawner?logo=pypi)](https://pypi.org/project/dockerspawner/)
 [![Documentation build status](https://img.shields.io/readthedocs/jupyterhub?logo=read-the-docs)](https://jupyterhub-dockerspawner.readthedocs.org/en/latest/)
 [![GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/dockerspawner/issues)


### PR DESCRIPTION
We had a TravisCI badge that we shouldn't have.

![image](https://user-images.githubusercontent.com/3837114/109169939-9be61b00-7780-11eb-8882-fe6d69f2c77a.png)