### PR TITLE
add 'skip' option for pull_policy

### DIFF
--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -26,6 +26,12 @@ class SwarmSpawner(DockerSpawner):
     object_type = "service"
     object_id_key = "ID"
 
+    @default("pull_policy")
+    def _default_pull_policy(self):
+        # pre-pulling doesn't usually make sense on swarm
+        # unless it's a single-node cluster, so skip it by efault
+        return "skip"
+
     @property
     def service_id(self):
         """alias for object_id"""


### PR DESCRIPTION
skips unhelpful pull by default on swarm because the pull won't usually happen on the same node as the container anyway

closes #394