### PR TITLE
add SystemUserSpawner.run_as_root

### DIFF
--- a/dockerspawner/systemuserspawner.py
+++ b/dockerspawner/systemuserspawner.py
@@ -219,5 +219,11 @@ class SystemUserSpawner(DockerSpawner):
             if self.group_id >= 0:
                 user_s = f"{user_s}:{self.group_id}"
             self.extra_create_kwargs.setdefault('user', user_s)
+        elif self.group_id >= 0:
+            # group_id set, but user_id not set.
+            # this doesn't make sense.
+            self.log.warning(
+                f"user_id for {self.user.name} not set, but group_id is {self.group_id}. This will have no effect."
+            )
 
         return super(SystemUserSpawner, self).start()


### PR DESCRIPTION
when True, defer to image handing of $NB_UID and $NB_GID

this was previously a hard-to-opt-out default, but I think should be opt-in because images that do not support this will run all uses as root by default.

Downside of off-by-default: it's an extra flag needed to use docker-stacks to their full potential (they should still work without it, though, but usernames will not match, etc.)

Upside: userid is always right by default, no matter what image you use, no longer launch images as root that don't need it

closes #311
closes #283