### PR TITLE
Make escaping DNS-safe

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -341,13 +341,13 @@ class DockerSpawner(Spawner):
             It is important to include {servername} if JupyterHub's "named
             servers" are enabled (JupyterHub.allow_named_servers = True).
             If the server is named, the default name_template is
-            "{prefix}-{username}__{servername}". If it is unnamed, the default
+            "{prefix}-{username}--{servername}". If it is unnamed, the default
             name_template is "{prefix}-{username}".
 
             Note: when using named servers,
             it is important that the separator between {username} and {servername}
             is not a character that can occur in an escaped {username},
-            and also not the single escape character '_'.
+            and also not the single escape character '-'.
             """
         ),
     )
@@ -355,7 +355,7 @@ class DockerSpawner(Spawner):
     @default('name_template')
     def _default_name_template(self):
         if self.name:
-            return "{prefix}-{username}__{servername}"
+            return "{prefix}-{username}--{servername}"
         else:
             return "{prefix}-{username}"
 
@@ -571,8 +571,60 @@ class DockerSpawner(Spawner):
         config=True, help="Additional args to create_host_config for container create"
     )
 
-    _docker_safe_chars = set(string.ascii_letters + string.digits + "-")
-    _docker_escape_char = "_"
+    escape = Any(
+        help="""Override escaping with any callable of the form escape(str)->str
+
+        This is used to ensure docker-safe container names, etc.
+
+        The default escaping should ensure safety and validity,
+        but can produce cumbersome strings in cases.
+
+        Set c.DockerSpawner.escape = 'legacy' to preserve the earlier, unsafe behavior
+        if it worked for you.
+
+        .. versionadded:: 0.12
+
+        .. versionchanged:: 0.12
+            Escaping has changed in 0.12 to ensure safety,
+            but existing deployments will get different container and volume names.
+        """,
+        config=True,
+    )
+
+    @default("escape")
+    def _escape_default(self):
+        return self._escape
+
+    @validate("escape")
+    def _validate_escape(self, proposal):
+        escape = proposal.value
+        if escape == "legacy":
+            return self._legacy_escape
+        if not callable(escape):
+            raise ValueError("DockerSpawner.escape must be callable, got %r" % escape)
+        return escape
+
+    @staticmethod
+    def _escape(text):
+        # Make sure a substring matches the restrictions for DNS labels
+        # Note: '-' cannot be in safe_chars, as it is being used as escape character
+        # any '-' must be escaped to '-2d' to avoid collisions
+        safe_chars = set(string.ascii_lowercase + string.digits)
+        return escape(text, safe_chars, escape_char='-').lower()
+
+    @staticmethod
+    def _legacy_escape(text):
+        """Legacy implementation of escape
+
+        Select with config c.DockerSpawner.escape = 'legacy'
+
+        Unsafe and doesn't work in all cases,
+        but allows opt-in to backward compatibility for an upgrading deployment.
+
+        Do not use for new deployments.
+        """
+        safe_chars = set(string.ascii_letters + string.digits + "-")
+        return escape(text, safe_chars, escape_char='_')
 
     hub_ip_connect = Unicode(
         config=True,
@@ -761,23 +813,15 @@ class DockerSpawner(Spawner):
     def escaped_name(self):
         """Escape the username so it's safe for docker objects"""
         if self._escaped_name is None:
-            self._escaped_name = self._escape(self.user.name)
+            self._escaped_name = self.escape(self.user.name)
         return self._escaped_name
-
-    def _escape(self, s):
-        """Escape a string to docker-safe characters"""
-        return escape(
-            s,
-            safe=self._docker_safe_chars,
-            escape_char=self._docker_escape_char,
-        )
 
     object_id = Unicode(allow_none=True)
 
     def template_namespace(self):
-        escaped_image = self.image.replace("/", "_")
+        escaped_image = self.image.replace("/", "-")
         server_name = getattr(self, "name", "")
-        safe_server_name = self._escape(server_name.lower())
+        safe_server_name = self.escape(server_name.lower())
         return {
             "username": self.escaped_name,
             "safe_username": self.escaped_name,

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -23,7 +23,9 @@ def test_name_collision(dockerspawner_configured_app):
     user = app.users[has_hyphen]
     spawner1 = user.spawners[""]
     assert isinstance(spawner1, DockerSpawner)
-    assert spawner1.object_name == "{}-{}".format(spawner1.prefix, has_hyphen)
+    assert spawner1.object_name == "{}-{}".format(
+        spawner1.prefix, has_hyphen.replace("-", "-2d")
+    )
 
     part1, part2 = ["user", "foo"]
     add_user(app.db, app, name=part1)

--- a/tests/volumes_test.py
+++ b/tests/volumes_test.py
@@ -50,7 +50,7 @@ def test_default_format_volume_name(monkeypatch):
     d.user = types.SimpleNamespace(name="user@email.com")
     d.volumes = {"data/{username}": {"bind": "/home/{raw_username}", "mode": "z"}}
     assert d.volume_binds == {
-        "data/user_40email_2Ecom": {"bind": "/home/user@email.com", "mode": "z"}
+        "data/user-40email-2ecom": {"bind": "/home/user@email.com", "mode": "z"}
     }
     assert d.volume_mount_points == ["/home/user@email.com"]
 
@@ -64,9 +64,9 @@ def test_escaped_format_volume_name(monkeypatch):
     d.volumes = {"data/{username}": {"bind": "/home/{username}", "mode": "z"}}
     d.format_volume_name = dockerspawner.volumenamingstrategy.escaped_format_volume_name
     assert d.volume_binds == {
-        "data/user_40email_2Ecom": {"bind": "/home/user_40email_2Ecom", "mode": "z"}
+        "data/user-40email-2ecom": {"bind": "/home/user-40email-2ecom", "mode": "z"}
     }
-    assert d.volume_mount_points == ["/home/user_40email_2Ecom"]
+    assert d.volume_mount_points == ["/home/user-40email-2ecom"]
 
 
 class _MockSpawner(LoggingConfigurable):


### PR DESCRIPTION
While containers allow more characters, networking and the like are more strict.

To ensure things like DNS work (required for swarm, internal ssl), use a stricter DNS-safe subset for escaping.

c.DockerSpawner.escape is now a configurable and can be overridden to preserve old behavior and/or use other schemes.

closes #205
closes #326
closes #305
closes #342
closes #262
closes #209