### PR TITLE
(PATCH) SwarmSpawner, InvalidArgument: Incompatible options have been provided for the bind type mount.

### DIFF
--- a/dockerspawner/swarmspawner.py
+++ b/dockerspawner/swarmspawner.py
@@ -109,9 +109,11 @@ class SwarmSpawner(DockerSpawner):
 
     @property
     def mount_driver_config(self):
-        return DriverConfig(
-            name=self.volume_driver, options=self.volume_driver_options or None
-        )
+        if self.volume_driver:
+            return DriverConfig(
+                name=self.volume_driver, options=self.volume_driver_options or None
+            )
+        return None
 
     @property
     def mounts(self):


### PR DESCRIPTION
Error: SwarmSpawner, InvalidArgument: Incompatible options have been provided for the bind type mount.

Scenario: https://github.com/jupyterhub/dockerspawner/issues/263

I solved this issue, subclassing SwarmSpawner:

Creation of a module "modspawner.py"

`from dockerspawner import SwarmSpawner

class ModSwarmSpawner(SwarmSpawner):
    @Property
    def mount_driver_config(self):
        if self.volume_driver:
        return DriverConfig(
            name=self.volume_driver, options=self.volume_driver_options or None
        )
        return None`

Add to JupyterHub settings:
`c.JupyterHub.spawner_class = 'modspawner.ModSwarmSpawner'`

The main reason is because of a improprely implementation of mount_driver_config method, of the SwarmSpawner Class.
This methods always returns a DriverConfig, even if no driver config was set.

When the spawner calls to create a Service, it creates a docker.types.services.Mount Object, and it checks if driver_config evaluates False. Due to the driver_config always returns a DriverConfig Object (that evaluates True), it always throws a "'Incompatible options have been provided for the bind type mount." error. This subclass solves this problem and I will make a pull request to aplly this on the main repo.

References:
https://ask.csdn.net/questions/5861756
https://github.com/jupyterhub/dockerspawner/issues/263
https://github.com/docker/docker-py/blob/31775a1532a66cf8a4c183a99bb5c73623147295/docker/types/services.py#L240