### PR TITLE
Allow to specify a callable for `mem_limit`

### DIFF
--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import docker
 import pytest
+import traitlets
 from jupyterhub.tests.mocking import public_url
 from jupyterhub.tests.test_api import add_user
 from jupyterhub.tests.test_api import api_request
@@ -219,3 +220,20 @@ async def test_post_start(dockerspawner_configured_app, caplog):
             assert "post_start stderr" not in logged
 
     await spawner.stop()
+
+
+@pytest.mark.skipif(
+    traitlets.__version__ < '5.0', reason="One test fails on traitlets < 5.0. See #420."
+)
+@pytest.mark.parametrize(
+    "mem_limit, expected",
+    [
+        ("1G", 1024 ** 3),
+        (1_000_000, 1_000_000),
+        (lambda spawner: "2G", 2 * 1024 ** 3),
+        (lambda spawner: 1_000_000, 1_000_000),
+    ],
+)
+def test_mem_limit(mem_limit, expected):
+    s = DockerSpawner(mem_limit=mem_limit)
+    assert s.mem_limit == expected


### PR DESCRIPTION
Similarly to the `allowed_images` setting, it would be very convenient to be able to set the `mem_limit` to a callable, to have more flexibility to enforce memory limits.

This feature would for instance allow easily define user-specific memory limits in `jupyterhub_config.py`:

```python
def per_user_mem_limit(spawner):
    username = spawner.user.name
    ram_limits = {}
    try:
        with open("/srv/jupyterhub/ram_limits.json") as f:
            ram_limits = json.load(f)
    except:
        pass
    return ram_limits.get(username, "32G")
c.SystemUserSpawner.mem_limit = per_user_mem_limit
```
