### PR TITLE
support cpu limit via cpu_quota / cpu_period

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,3 +160,13 @@ def debug_docker(request, docker):
             sort_keys=True,
         )
         print(f"Container {c.name}: {container_info}")
+
+
+_username_counter = 0
+
+
+@pytest.fixture()
+def username():
+    global _username_counter
+    _username_counter += 1
+    return f"test-user-{_username_counter}"


### PR DESCRIPTION
according to [the docs](https://docs.docker.com/config/containers/resource_constraints/#cpu) we need to specify cpu_quota in terms of cpu_period. The default period is 100ms

closes #428