### PR TITLE
Add Podman to docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
             jupyterhub: 1.2
           - python: 3.9
             jupyterhub: 1.3
+          - python: "3.10"
+            jupyterhub: "1.4"
+            test: podman
 
     steps:
       - uses: actions/checkout@v2
@@ -81,6 +84,7 @@ jobs:
           npm install -g configurable-http-proxy
 
       - name: Pull images
+        if: matrix.test != 'podman'
         run: |
           for v in 1.0 1.1 1.2 1.3; do
             docker pull jupyterhub/singleuser:$v
@@ -91,7 +95,7 @@ jobs:
           done
 
       - name: Run tests
-        if: matrix.test != 'internal-ssl'
+        if: matrix.test != 'internal-ssl' && matrix.test != 'podman'
         run: |
           py.test --cov dockerspawner tests -v
 
@@ -100,6 +104,23 @@ jobs:
         run: |
           cd examples/internal-ssl
           pytest -vsx
+
+      - name: Run user-mode podman tests
+        if: matrix.test == 'podman'
+        run: |
+          sudo systemctl stop docker
+          # Default is unix://$XDG_RUNTIME_DIR/podman/podman.sock but XDG_RUNTIME_DIR may not be set
+          export DOCKER_HOST=unix://$HOME/podman.sock
+          podman system service --time=0 $DOCKER_HOST &
+          for n in $(seq 1 10); do
+            if ! docker version; then
+              sleep 2
+            else
+              break
+            fi
+          done
+          docker ps
+          py.test --cov dockerspawner tests/test_dockerspawner.py -v
 
       - name: Submit codecov report
         run: |

--- a/docs/source/spawner-types.md
+++ b/docs/source/spawner-types.md
@@ -147,3 +147,19 @@ c.DockerSpawner.host_ip = "0.0.0.0"
 This will configure DockerSpawner and SystemUserSpawner to get
 the container IP address and port number using the `docker port`
 command.
+
+## Using Podman
+
+Podman is an alternative to Docker for running containers, and supports running containers without root access.
+It is not supported by JupyterHub, but it can be used with DockerSpawner by [running a podman service](https://docs.podman.io/en/latest/markdown/podman-system-service.1.html):
+
+```sh
+podman system service --time=0 &
+export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
+# Run jupyterhub as normal
+jupyterhub --config=jupyterhub_config.py
+```
+
+There are several other ways of [running the Podman service](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_using-the-container-tools-api_building-running-and-managing-containers).
+
+Not all Docker features are supported by Podman.

--- a/docs/source/spawner-types.md
+++ b/docs/source/spawner-types.md
@@ -151,7 +151,7 @@ command.
 ## Using Podman
 
 Podman is an alternative to Docker for running containers, and supports running containers without root access.
-It is not supported by JupyterHub, but it can be used with DockerSpawner by [running a podman service](https://docs.podman.io/en/latest/markdown/podman-system-service.1.html):
+It is not officially supported by JupyterHub, but it can be used with DockerSpawner by [running a podman service](https://docs.podman.io/en/latest/markdown/podman-system-service.1.html):
 
 ```sh
 podman system service --time=0 &

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import logging
+import os
 from unittest import mock
 
 import docker
@@ -111,6 +112,9 @@ async def test_allowed_image(dockerspawner_configured_app, image):
     r.raise_for_status()
 
 
+@pytest.mark.xfail(
+    "podman.sock" in os.getenv("DOCKER_HOST", ""), reason="Fails with Podman"
+)
 async def test_image_pull_policy(dockerspawner_configured_app):
     app = dockerspawner_configured_app
     name = "gumby"


### PR DESCRIPTION
DockerSpawner more or less works with Podman, to the point where most of the DockerSpawner tests pass! Setting up Podman as a daemon (required for compatibility with Docker) has also gotten a lot easier so now it's just a single command.

Closes https://github.com/jupyterhub/dockerspawner/issues/360