### PR TITLE
add generate-certs service to internal-ssl example

### DIFF
--- a/examples/internal-ssl/.env
+++ b/examples/internal-ssl/.env
@@ -13,7 +13,7 @@ DOCKER_MACHINE_NAME=jupyterhub
 DOCKER_NETWORK_NAME=jupyterhub
 
 # Single-user Jupyter Notebook server container image
-DOCKER_NOTEBOOK_IMAGE=jupyterhub/singleuser:1.3.0
+DOCKER_NOTEBOOK_IMAGE=jupyterhub/singleuser:1
 
 # Name of JupyterHub container data volume
 DATA_VOLUME_HOST=jupyterhub-data

--- a/examples/internal-ssl/Dockerfile
+++ b/examples/internal-ssl/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyterhub/jupyterhub:1.3.0
+FROM jupyterhub/jupyterhub:1
 COPY setup.py /src/dockerspawner/setup.py
 COPY requirements.txt /src/dockerspawner/requirements.txt
 RUN pip install -r /src/dockerspawner/requirements.txt

--- a/examples/internal-ssl/README.md
+++ b/examples/internal-ssl/README.md
@@ -5,7 +5,7 @@ JupyterHub 1.0 introduces internal_ssl configuration for encryption and authenti
 DockerSpawner implements the `.move_certs` method necessary,
 so no additional configuration
 
-This directory contains a docker-compose configuration to deploy jupyterhub 1.0
+This directory contains a docker-compose configuration to deploy jupyterhub
 with configurable-http-proxy and total internal encryption.
 
 To use it:

--- a/examples/internal-ssl/docker-compose.yml
+++ b/examples/internal-ssl/docker-compose.yml
@@ -6,8 +6,12 @@ version: "3"
 
 services:
   proxy:
+    depends_on:
+      generate-certs:
+        condition: service_completed_successfully
+
     container_name: proxy
-    image: jupyterhub/configurable-http-proxy:4.3.1
+    image: jupyterhub/configurable-http-proxy:4.5.0
     restart: always
     environment:
       CONFIGPROXY_AUTH_TOKEN: ${CONFIGPROXY_AUTH_TOKEN}
@@ -21,6 +25,11 @@ services:
       default:
         aliases:
           - proxy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/_chp_healthz"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
     command: >
       configurable-http-proxy
       --port 8000
@@ -38,10 +47,37 @@ services:
       --client-ssl-request-cert
       --client-ssl-reject-unauthorized
 
+  # this is identical to the hub service
+  # but runs the `--generate-certs` step first
+  generate-certs:
+    user: "0:0"
+    build:
+      context: ../..
+      dockerfile: examples/internal-ssl/Dockerfile
+    restart: "no"
+    image: jupyterhub/jupyterhub:internal-ssl
+    volumes:
+      - "ssl:${SSL_VOLUME_CONTAINER}:rw"
+    environment:
+      PYTHONUNBUFFERED: "1"
+      CONFIGPROXY_AUTH_TOKEN: ${CONFIGPROXY_AUTH_TOKEN}
+      # All containers will join this network
+      DOCKER_NETWORK_NAME: ${DOCKER_NETWORK_NAME}
+      # JupyterHub will spawn this Notebook image for users
+      DOCKER_NOTEBOOK_IMAGE: ${DOCKER_NOTEBOOK_IMAGE}
+      # SSL path
+      INTERNAL_SSL_PATH: ${SSL_VOLUME_CONTAINER}/certs
+    working_dir: ${DATA_VOLUME_CONTAINER}
+    command: >
+      jupyterhub -f /srv/jupyterhub/jupyterhub_config.py --generate-certs
+
   hub:
     user: "0:0"
     depends_on:
-      - proxy
+      proxy:
+        condition: service_healthy
+      generate-certs:
+        condition: service_completed_successfully
     build:
       context: ../..
       dockerfile: examples/internal-ssl/Dockerfile

--- a/examples/internal-ssl/jupyterhub_config.py
+++ b/examples/internal-ssl/jupyterhub_config.py
@@ -9,20 +9,6 @@ c.JupyterHub.authenticator_class = 'dummy'
 
 c.JupyterHub.spawner_class = 'docker'
 
-# wait for proxy DNS to resolve
-# hub startup will crash if it doesn't
-for i in range(30):
-    try:
-        socket.gethostbyname("proxy")
-    except socket.gaierror as e:
-        socket_error = e
-        print(f"Waiting for proxy: {e}", file=sys.stderr)
-        time.sleep(1)
-    else:
-        break
-else:
-    raise socket_error
-
 c.ConfigurableHTTPProxy.should_start = False
 c.ConfigurableHTTPProxy.api_url = 'https://proxy:8001'
 


### PR DESCRIPTION
Has to mostly be a duplicate of the jupyterhub service, just to load the config.

This service runs to completion, to ensure the certificates are created

- proxy requires generate-certs to finish, which ensures the certs are available, otherwise proxy would crash
- hub requires proxy to be responsive, which should ensure proxy DNS is defined

removes DNS check from hub config, which should be redundant with the added healthy-proxy condition

I think this closes #445 which was caused by the hub and proxy needing to wait for each other:

- hub waits for proxy DNS to resolve, which is only true while proxy is running
- proxy crashes if certs don't exist, creating a race where the proxy container must exist (so that the hub can start), but not have tried to read the certs, else it will crash

