### PR TITLE
update versions in swarm example

### DIFF
--- a/examples/swarm/Dockerfile
+++ b/examples/swarm/Dockerfile
@@ -1,7 +1,7 @@
 # base image: jupyterhub
 # this is built by docker-compose
 # from the root of this repo
-ARG JUPYTERHUB_VERSION=1.3.0
+ARG JUPYTERHUB_VERSION=2.2
 FROM jupyterhub/jupyterhub:${JUPYTERHUB_VERSION}
 # install dockerspawner from the current repo
 ADD . /tmp/dockerspawner

--- a/examples/swarm/docker-compose.yml
+++ b/examples/swarm/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   proxy:
     env_file: .env
-    image: jupyterhub/configurable-http-proxy:4.3.1
+    image: jupyterhub/configurable-http-proxy:4.5
     networks:
       - jupyterhub-net
     # expose the proxy to the world
@@ -27,3 +27,4 @@ services:
 networks:
   jupyterhub-net:
     driver: overlay
+    attachable: true


### PR DESCRIPTION
add newly required attachable arg to network (required in compose 3.2, apparently)

closes #452