### PR TITLE
Fix imagename not to include letter ':'

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -868,7 +868,7 @@ class DockerSpawner(Spawner):
     object_id = Unicode(allow_none=True)
 
     def template_namespace(self):
-        escaped_image = self.image.replace("/", "-")
+        escaped_image = self.image.replace("/", "-").replace(":", "-")
         server_name = getattr(self, "name", "")
         safe_server_name = self.escape(server_name.lower())
         return {


### PR DESCRIPTION
`imagename` is currently set to like `"binder-examples-conda:HEAD"`, and a colon `:` is problematic when used as a part of a docker volume name.

```python
c.DockerSpawner.volumes = { 'jupyterhub-user-{username}--{imagename}': notebook_dir }
```

This PR sets `imagename` to be `"binder-examples-conda-HEAD"`, instead.