### PR TITLE
update object_name with current image

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -1266,7 +1266,7 @@ class DockerSpawner(Spawner):
             self.object_name = await self._object_name_for_current_image()
 
         image = self.image
-        await self.pull_imt self._object_name_default()age(image)
+        await self.pull_image(image)
 
         obj = await self.get_object()
         if obj and self.remove:

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -888,9 +888,10 @@ class DockerSpawner(Spawner):
         """Render the name of our container/service using name_template"""
         return self._render_templates(self.name_template)
 
-    async def _object_name_for_current_image(self):
-        """Render the name of our container/service using name_template"""
-        return self._render_templates(self.name_template)
+    @observe("image")
+    def _image_changed(self, change):
+        # re-render object name if image changes
+        self.object_name = self._object_name_default()
 
     def load_state(self, state):
         super(DockerSpawner, self).load_state(state)
@@ -1263,7 +1264,6 @@ class DockerSpawner(Spawner):
         if image_option:
             # save choice in self.image
             self.image = await self.check_allowed(image_option)
-            self.object_name = await self._object_name_for_current_image()
 
         image = self.image
         await self.pull_image(image)

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -887,6 +887,10 @@ class DockerSpawner(Spawner):
     def _object_name_default(self):
         """Render the name of our container/service using name_template"""
         return self._render_templates(self.name_template)
+    
+    async def _object_name_for_current_image(self):
+        """Render the name of our container/service using name_template"""
+        return self._render_templates(self.name_template)
 
     def load_state(self, state):
         super(DockerSpawner, self).load_state(state)
@@ -1259,9 +1263,10 @@ class DockerSpawner(Spawner):
         if image_option:
             # save choice in self.image
             self.image = await self.check_allowed(image_option)
+            self.object_name = await self._object_name_for_current_image()
 
         image = self.image
-        await self.pull_image(image)
+        await self.pull_imt self._object_name_default()age(image)
 
         obj = await self.get_object()
         if obj and self.remove:

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -887,7 +887,7 @@ class DockerSpawner(Spawner):
     def _object_name_default(self):
         """Render the name of our container/service using name_template"""
         return self._render_templates(self.name_template)
-    
+
     async def _object_name_for_current_image(self):
         """Render the name of our container/service using name_template"""
         return self._render_templates(self.name_template)


### PR DESCRIPTION
When several images allowed in dockerspawner and template_name is containing {imagename}, it would be expected that the selected image name is used within the object_name. I didn't found a way to do it as object_name is using default image name if not specified.
This fix updates object_name at container start after check_allowed image. It is working at least for the above use case, don't know if it is the best way to do it and if it has other consequences elsewhere. Also, I set the method _object_name_for_current_image as an async method but I am not very familiar with that method type, so here also I am not sure it is needed.

Hopping it can help, many thanks for that package anyway.