### PR TITLE
catch TypeError in teardown for podman

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,8 +118,9 @@ def docker():
                 c.remove()
         try:
             services = d.services.list()
-        except APIError:
+        except (APIError, TypeError):
             # e.g. services not available
+            # podman gives TypeError
             return
         else:
             for s in services:


### PR DESCRIPTION
d.services.list throws TypeError instead of APIError with podman