### PR TITLE
added a config option for easy gpu sharing to DockerSpawner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,5 @@
 # DockerSpawner
 
-## Fork README
-This fork adds a config option to easily share specific GPUs with containers spawned by the DockerSpawner. I have created a pull request but until it is merged, you can install the package by:
-```bash
-pip install git+https://github.com/indirected/dockerspawner.git
-```
-### Here is how you use the config option:
-```python
-c.DockerSpawner.gpu_ids = None # Will not share GPUs with containers
-c.DockerSpawner.gpu_ids = 'all' # Shares all the GPUs with containers
-c.DockerSpawner.gpu_ids = '0' # Shares GPU of ID 0 with containers
-c.DockerSpawner.gpu_ids = '0,1,2' # Shares GPUs of IDs 0, 1 and 2 with containers
-```
-Alternatively, you can pass a callable that takes the spawner as
-the only argument and returns one of the above acceptable values:
-```python
-def per_user_gpu_ids(spawner):
-    username = spawner.user.name
-    gpu_assign = {'alice': '0', 'bob': '1,2'}
-    return gpu_assign.get(username, None)
-c.DockerSpawner.gpu_ids = per_user_gpu_ids
-```
-Note that before using this config option, you have to:
-  1. Install the Nvidia Container Toolkit and make sure your docker is able to run containers with gpu
-  2. Use an image with a CUDA version supported by your host's GPU driver
-
----
-
-## Original README
 [![GitHub Workflow Status - Test](https://img.shields.io/github/workflow/status/jupyterhub/dockerspawner/Tests?logo=github&label=tests)](https://github.com/jupyterhub/dockerspawner/actions)
 [![Latest PyPI version](https://img.shields.io/pypi/v/dockerspawner?logo=pypi)](https://pypi.org/project/dockerspawner/)
 [![Documentation build status](https://img.shields.io/readthedocs/jupyterhub?logo=read-the-docs)](https://jupyterhub-dockerspawner.readthedocs.org/en/latest/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 # DockerSpawner
 
+## Fork README
+This fork adds a config option to easily share specific GPUs with containers spawned by the DockerSpawner. I have created a pull request but until it is merged, you can install the package by:
+```bash
+pip install git+https://github.com/indirected/dockerspawner.git
+```
+### Here is how you use the config option:
+```python
+c.DockerSpawner.gpu_ids = None # Will not share GPUs with containers
+c.DockerSpawner.gpu_ids = 'all' # Shares all the GPUs with containers
+c.DockerSpawner.gpu_ids = '0' # Shares GPU of ID 0 with containers
+c.DockerSpawner.gpu_ids = '0,1,2' # Shares GPUs of IDs 0, 1 and 2 with containers
+```
+Alternatively, you can pass a callable that takes the spawner as
+the only argument and returns one of the above acceptable values:
+```python
+def per_user_gpu_ids(spawner):
+    username = spawner.user.name
+    gpu_assign = {'alice': '0', 'bob': '1,2'}
+    return gpu_assign.get(username, None)
+c.DockerSpawner.gpu_ids = per_user_gpu_ids
+```
+Note that before using this config option, you have to:
+  1. Install the Nvidia Container Toolkit and make sure your docker is able to run containers with gpu
+  2. Use an image with a CUDA version supported by your host's GPU driver
+
+---
+
+## Original README
 [![GitHub Workflow Status - Test](https://img.shields.io/github/workflow/status/jupyterhub/dockerspawner/Tests?logo=github&label=tests)](https://github.com/jupyterhub/dockerspawner/actions)
 [![Latest PyPI version](https://img.shields.io/pypi/v/dockerspawner?logo=pypi)](https://pypi.org/project/dockerspawner/)
 [![Documentation build status](https://img.shields.io/readthedocs/jupyterhub?logo=read-the-docs)](https://jupyterhub-dockerspawner.readthedocs.org/en/latest/)

--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -1171,7 +1171,7 @@ class DockerSpawner(Spawner):
             binds=self.volume_binds,
             links=self.links,
             mounts=self.mount_binds,
-            device_requests = [],
+            device_requests=[],
         )
 
         if getattr(self, "mem_limit", None) is not None:
@@ -1188,7 +1188,9 @@ class DockerSpawner(Spawner):
 
         if getattr(self, "gpu_ids", None) is not None:
             host_config['device_requests'].append(
-                docker.types.DeviceRequest(device_ids=[f"{self.gpu_ids}"], capabilities=[['gpu']])
+                docker.types.DeviceRequest(
+                    device_ids=[f"{self.gpu_ids}"], capabilities=[['gpu']]
+                )
             )
 
         if not self.use_internal_ip:


### PR DESCRIPTION
I added a config option: `gpu_ids` to make sharing GPUs with containers a little bit easier and tried to keep the style close to `cpu_limit` and `mem_limit`.
Also, How it works is documented with the help parameter.

Edit: I'm kind of new to the open-source community, sorry if something is missing. comments are appreciated!