### PR TITLE
Add test strategy for JupyterHub v3.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
         include:
           - python: 3.8
             test: internal-ssl
-          - python: 3.6
-            jupyterhub: "1.0"
           - python: 3.7
             jupyterhub: 1.5
           - python: 3.8
@@ -31,6 +29,8 @@ jobs:
           - python: "3.10"
             jupyterhub: "2.1"
             test: podman
+          - python: 3.11
+            jupyterhub: 3.1.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
           - python: "3.10"
             jupyterhub: "2.1"
             test: podman
+          - python: 3.9
+            jupyterhub: 3.1.1
           - python: 3.11
             jupyterhub: 3.1.1
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,3 @@ pyflakes
 pytest>=3.6
 pytest-asyncio
 pytest-cov
-sqlalchemy==1.*

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ pyflakes
 pytest>=3.6
 pytest-asyncio
 pytest-cov
+sqlalchemy==1.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,14 @@ target_version = [
     "py310",
     "py311",
 ]
+
+
+# pytest is used for running Python based tests
+#
+# ref: https://docs.pytest.org/en/stable/
+#
+[tool.pytest.ini_options]
+addopts = "--verbose --color=yes --durations=10"
+asyncio_mode = "auto"
+# Ignore thousands of tests in dependencies installed in a virtual environment
+norecursedirs = "lib lib64"

--- a/tests/test_dockerspawner.py
+++ b/tests/test_dockerspawner.py
@@ -17,9 +17,6 @@ from tornado.httpclient import AsyncHTTPClient
 
 from dockerspawner import DockerSpawner
 
-# Mark all tests in this file as asyncio
-pytestmark = pytest.mark.asyncio
-
 
 def test_name_collision(dockerspawner_configured_app):
     app = dockerspawner_configured_app

--- a/tests/test_swarmspawner.py
+++ b/tests/test_swarmspawner.py
@@ -7,9 +7,6 @@ from tornado.httpclient import AsyncHTTPClient
 
 from dockerspawner import SwarmSpawner
 
-# Mark all tests in this file as asyncio
-pytestmark = pytest.mark.asyncio
-
 
 async def test_start_stop(swarmspawner_configured_app):
     app = swarmspawner_configured_app

--- a/tests/test_systemuserspawner.py
+++ b/tests/test_systemuserspawner.py
@@ -9,9 +9,6 @@ from tornado.httpclient import AsyncHTTPClient
 
 from dockerspawner import SystemUserSpawner
 
-# Mark all tests in this file as asyncio
-pytestmark = pytest.mark.asyncio
-
 
 async def test_start_stop(systemuserspawner_configured_app):
     app = systemuserspawner_configured_app


### PR DESCRIPTION
- removed matrix config for Python 3.6 since it reached [end of life](https://endoflife.date/python)
- added matrix config for Python 3.9 using JupyterHub 3.1.1
- added matrix config for Python 3.11 using JupyterHub 3.1.1

Reference #476 