### PR TITLE
Add initial_user traitlet to change user that container is started with

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -195,6 +195,23 @@ class DockerSpawner(Spawner):
     def _ip_default(self):
         return "0.0.0.0"
 
+    initial_user = Unicode(
+        "jovyan",
+        help="""
+        The initial user with which to start the container
+
+        The [default user for Jupyter Docker stacks](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-docker-stacks-foundation) is 'jovyan'
+
+        You may need to set this value to 'root', which is equivalent to
+        `docker run --user root`. This is necessary when e.g. changing jovyan's
+        default UID or home directory permissions
+
+        Jupyter Docker stacks will switch back to jovyan before starting the notebook server (e.g. JupyterLab)
+        The end-user within the container *will not* be the user set here, unless you are using a modified image
+        """,
+        config=True,
+    )
+
     container_image = Unicode(
         "jupyterhub/singleuser:%s" % _jupyterhub_xy,
         help="Deprecated, use `DockerSpawner.image.`",
@@ -1123,6 +1140,7 @@ class DockerSpawner(Spawner):
             volumes=self.volume_mount_points,
             name=self.container_name,
             command=(await self.get_command()),
+            user=self.initial_user,
         )
 
         # ensure internal port is exposed


### PR DESCRIPTION
This PR adds the `initial_user` traitlet, which may be used to change the user that the spawned container is started with.

Per my [comment here](https://github.com/jupyterhub/dockerspawner/issues/453#issuecomment-1640502595) I was encountering a mounted directory with `root` permissions that meant the default `jovyan` user had no access.

In order to follow the [suggestion here](https://github.com/jupyter/docker-stacks/issues/1003#issuecomment-583768897), I needed DockerSpawner to start the container as `root` so that the permissions may be changed. This can be done via this traitlet like so:

```python
c.DockerSpawner.initial_user = "root"
```

This PR is inspired by [this comment](https://github.com/jupyterhub/dockerspawner/issues/154#issuecomment-355477006), which I saw was not yet implemented. It is useful beyond my specific case, such as when changing [user-related configuration](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#user-related-configurations) in a Jupyter Docker Stack