### PR TITLE
propagation support for bind mounts (once docker-py supports it officially)

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -1419,12 +1419,15 @@ class DockerSpawner(Spawner):
             return self.format_volume_name(v, self)
 
         for k, v in volumes.items():
-            m = mode
+            rw = mode
+            p = 'rprivate'
             if isinstance(v, dict):
                 if "mode" in v:
-                    m = v["mode"]
+                    rw = v["mode"]
+                if "propagation" in v:
+                    p = v["propagation"]
                 v = v["bind"]
-            binds[_fmt(k)] = {"bind": _fmt(v), "mode": m}
+            binds[_fmt(k)] = {"bind": _fmt(v), "mode": rw, 'propagation': p}
         return binds
 
     def _render_templates(self, obj, ns=None):

--- a/tests/volumes_test.py
+++ b/tests/volumes_test.py
@@ -14,13 +14,13 @@ def test_binds(monkeypatch):
     d.user = types.SimpleNamespace(name="xyz")
     d.volumes = {"a": "b", "c": {"bind": "d", "mode": "Z"}}
     assert d.volume_binds == {
-        "a": {"bind": "b", "mode": "rw"},
-        "c": {"bind": "d", "mode": "Z"},
+        "a": {"bind": "b", "mode": "rw", "propagation": 'rprivate'},
+        "c": {"bind": "d", "mode": "Z", "propagation": 'rprivate'},
     }
     d.volumes = {"a": "b", "c": "d", "e": "f"}
     assert d.volume_mount_points == ["b", "d", "f"]
     d.volumes = {"/nfs/{username}": {"bind": "/home/{username}", "mode": "z"}}
-    assert d.volume_binds == {"/nfs/xyz": {"bind": "/home/xyz", "mode": "z"}}
+    assert d.volume_binds == {"/nfs/xyz": {"bind": "/home/xyz", "mode": "z", "propagation": 'rprivate'}}
     assert d.volume_mount_points == ["/home/xyz"]
 
 
@@ -35,7 +35,7 @@ def test_volume_naming_configuration(monkeypatch):
         return "THIS IS A TEST"
 
     d.format_volume_name = test_format
-    assert d.volume_binds == {"THIS IS A TEST": {"bind": "THIS IS A TEST", "mode": "z"}}
+    assert d.volume_binds == {"THIS IS A TEST": {"bind": "THIS IS A TEST", "mode": "z", "propagation": 'rprivate'}}
     assert d.volume_mount_points == ["THIS IS A TEST"]
 
 
@@ -46,7 +46,7 @@ def test_default_format_volume_name(monkeypatch):
     d.user = types.SimpleNamespace(name="user@email.com")
     d.volumes = {"data/{username}": {"bind": "/home/{raw_username}", "mode": "z"}}
     assert d.volume_binds == {
-        "data/user-40email-2ecom": {"bind": "/home/user@email.com", "mode": "z"}
+        "data/user-40email-2ecom": {"bind": "/home/user@email.com", "mode": "z", "propagation": 'rprivate'}
     }
     assert d.volume_mount_points == ["/home/user@email.com"]
 
@@ -60,7 +60,7 @@ def test_escaped_format_volume_name(monkeypatch):
     d.volumes = {"data/{username}": {"bind": "/home/{username}", "mode": "z"}}
     d.format_volume_name = dockerspawner.volumenamingstrategy.escaped_format_volume_name
     assert d.volume_binds == {
-        "data/user-40email-2ecom": {"bind": "/home/user-40email-2ecom", "mode": "z"}
+        "data/user-40email-2ecom": {"bind": "/home/user-40email-2ecom", "mode": "z", "propagation": 'rprivate'}
     }
     assert d.volume_mount_points == ["/home/user-40email-2ecom"]
 

--- a/tests/volumes_test.py
+++ b/tests/volumes_test.py
@@ -20,7 +20,9 @@ def test_binds(monkeypatch):
     d.volumes = {"a": "b", "c": "d", "e": "f"}
     assert d.volume_mount_points == ["b", "d", "f"]
     d.volumes = {"/nfs/{username}": {"bind": "/home/{username}", "mode": "z"}}
-    assert d.volume_binds == {"/nfs/xyz": {"bind": "/home/xyz", "mode": "z", "propagation": 'rprivate'}}
+    assert d.volume_binds == {
+        "/nfs/xyz": {"bind": "/home/xyz", "mode": "z", "propagation": 'rprivate'}
+    }
     assert d.volume_mount_points == ["/home/xyz"]
 
 
@@ -35,7 +37,13 @@ def test_volume_naming_configuration(monkeypatch):
         return "THIS IS A TEST"
 
     d.format_volume_name = test_format
-    assert d.volume_binds == {"THIS IS A TEST": {"bind": "THIS IS A TEST", "mode": "z", "propagation": 'rprivate'}}
+    assert d.volume_binds == {
+        "THIS IS A TEST": {
+            "bind": "THIS IS A TEST",
+            "mode": "z",
+            "propagation": 'rprivate',
+        }
+    }
     assert d.volume_mount_points == ["THIS IS A TEST"]
 
 
@@ -46,7 +54,11 @@ def test_default_format_volume_name(monkeypatch):
     d.user = types.SimpleNamespace(name="user@email.com")
     d.volumes = {"data/{username}": {"bind": "/home/{raw_username}", "mode": "z"}}
     assert d.volume_binds == {
-        "data/user-40email-2ecom": {"bind": "/home/user@email.com", "mode": "z", "propagation": 'rprivate'}
+        "data/user-40email-2ecom": {
+            "bind": "/home/user@email.com",
+            "mode": "z",
+            "propagation": 'rprivate',
+        }
     }
     assert d.volume_mount_points == ["/home/user@email.com"]
 
@@ -60,7 +72,11 @@ def test_escaped_format_volume_name(monkeypatch):
     d.volumes = {"data/{username}": {"bind": "/home/{username}", "mode": "z"}}
     d.format_volume_name = dockerspawner.volumenamingstrategy.escaped_format_volume_name
     assert d.volume_binds == {
-        "data/user-40email-2ecom": {"bind": "/home/user-40email-2ecom", "mode": "z", "propagation": 'rprivate'}
+        "data/user-40email-2ecom": {
+            "bind": "/home/user-40email-2ecom",
+            "mode": "z",
+            "propagation": 'rprivate',
+        }
     }
     assert d.volume_mount_points == ["/home/user-40email-2ecom"]
 


### PR DESCRIPTION
I added a pull request for propagation support in docker-py (https://github.com/docker/docker-py/pull/3164) which has to be accepted before this PR makes any sense. 

Also I just realized that there seem to be other options (Mount specs???) in dockerspawner to enable propagation, but since documentation of docker-py is sparse, I couldn't figure out how to use that...

This might be helpful for others that want to use autofs in their jupyter-container launched by dockerspawner.