### PR TITLE
Update dockerspawner.py support mount `type` args

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -891,6 +891,8 @@ class DockerSpawner(Spawner):
             args = dict(mount)
             args["source"] = _fmt(mount["source"])
             args["target"] = _fmt(mount["target"])
+            args["type"] = mount.get("type", "volume")
+            args["read_only"] = mount.get("read_only", False)
             mounts.append(Mount(**args))
         return mounts
 


### PR DESCRIPTION
```python
class Mount(target, source, type='volume', read_only=False, consistency=None, propagation=None, no_copy=False, labels=None, driver_config=None, tmpfs_size=None, tmpfs_mode=None)
```

see https://docker-py.readthedocs.io/en/stable/api.html#docker.types.Mount