### PR TITLE
Revert "temporary pin for pytest-asyncio"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 netifaces
 notebook<7
 pytest>=3.6
-# FIXME: unpin pytest-asyncio
-pytest-asyncio>=0.17,<0.23
+pytest-asyncio>=0.17
 pytest-cov


### PR DESCRIPTION
Reverts jupyterhub/dockerspawner#514

needs to wait for fixes in pytest-asyncio itself, but opening WIP draft to track