### PR TITLE
compact debug log into single line

### DIFF
--- a/dockerspawner/dockerspawner.py
+++ b/dockerspawner/dockerspawner.py
@@ -3,13 +3,13 @@ A Spawner for JupyterHub that runs each user's server in a separate docker conta
 """
 import asyncio
 import inspect
+import json
 import os
 import string
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from io import BytesIO
-from pprint import pformat
 from tarfile import TarFile, TarInfo
 from textwrap import dedent, indent
 from urllib.parse import urlparse
@@ -1010,7 +1010,7 @@ class DockerSpawner(Spawner):
 
         container_state = container["State"]
         self.log.debug(
-            "Container %s status: %s", self.container_id[:7], pformat(container_state)
+            "Container %s status: %s", self.container_id[:7], json.dumps(container_state, ensure_ascii=False)
         )
 
         if container_state["Running"]:


### PR DESCRIPTION
replace pformat/pprint with json.dumps, so that the polled container status in log will be printed in a single line, which is friendly for logger collector and parser.