### PR TITLE
require Python 3.9, jupyterhub 4, unpin pytest-asyncio

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,10 +31,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # jupyterhub 4 works with pytest-asyncio 0.25
+          # but requires some deprecated features,
+          # so don't let it upgrade further
           - python-version: "3.9"
-            pip-install-spec: "jupyterhub==4.* sqlalchemy==1.*"
+            pip-install-spec: "jupyterhub==4.* sqlalchemy==1.* pytest-asyncio==0.25.*"
           - python-version: "3.11"
-            pip-install-spec: "jupyterhub==4.*"
+            pip-install-spec: "jupyterhub==4.* pytest-asyncio==0.25.*"
             test-variation: podman
           - python-version: "3.12"
             pip-install-spec: "jupyterhub==5.*"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,10 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.8"
-            pip-install-spec: "jupyterhub==2.3.1 sqlalchemy==1.*"
           - python-version: "3.9"
-            pip-install-spec: "jupyterhub==3.*"
+            pip-install-spec: "jupyterhub==4.* sqlalchemy==1.*"
           - python-version: "3.11"
             pip-install-spec: "jupyterhub==4.*"
             test-variation: podman

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ for more information about features and usage.
 
 ## Prerequisites
 
-Python 3.8 or above and JupyterHub 2.3.1 or above is required.
+Python 3.9 or above and JupyterHub 4 or above is required.
 
 ## Installation
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 netifaces
 notebook<7
 pytest>=3.6
-# FIXME: unpin pytest-asyncio
-pytest-asyncio>=0.17,<0.23
+pytest-asyncio>=0.17,!=0.23
 pytest-cov

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 netifaces
 notebook<7
 pytest>=3.6
-pytest-asyncio>=0.24
+pytest-asyncio>=0.25
 pytest-cov

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 netifaces
 notebook<7
 pytest>=3.6
-pytest-asyncio>=0.17,!=0.23
+pytest-asyncio>=0.24
 pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ profile = "black"
 [tool.black]
 skip-string-normalization = true
 target_version = [
-    "py38",
     "py39",
     "py310",
     "py311",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ target_version = [
 [tool.pytest.ini_options]
 addopts = "--verbose --color=yes --durations=10 --maxfail=1"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "module"
 testpaths = ["tests"]
 # These markers are registered to avoid warnings triggered by importing from
 # jupyterhub.tests.test_api.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 docker
 escapism
-jupyterhub>=2.3.1
+jupyterhub>=4

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup_args = dict(
             'docker-swarm = dockerspawner:SwarmSpawner',
         ],
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     cmdclass={
         'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """pytest config for dockerspawner tests"""
 
+import inspect
 import json
 import os
 from textwrap import indent
@@ -17,6 +18,10 @@ from jupyterhub.tests.conftest import io_loop  # noqa: F401
 from jupyterhub.tests.conftest import ssl_tmpdir  # noqa: F401
 from jupyterhub.tests.conftest import user  # noqa: F401
 from jupyterhub.tests.mocking import MockHub
+
+if 'event_loop' in inspect.signature(io_loop).parameters:
+    # older JupyterHub (< 5.x), io_loop requires deprecated event_loop
+    from jupyterhub.tests.conftest import event_loop  # noqa: F401
 
 from dockerspawner import DockerSpawner, SwarmSpawner, SystemUserSpawner
 


### PR DESCRIPTION
increase lower bound on pytest-asyncio to 0.24

this may create a problem for the older jupyterhub tests due to imported fixtures, but let's see...